### PR TITLE
Support mentions

### DIFF
--- a/packages/bot-utils/src/post.ts
+++ b/packages/bot-utils/src/post.ts
@@ -1,8 +1,8 @@
 import got, { HTTPError } from 'got';
 
+import { PostError } from './errors';
 import type { PostMeasurement, PostMeasurementResponse } from './types';
 import { userAgent } from './user-agent';
-import { PostError } from './utils';
 
 export const postMeasurement = async (optsArr: PostMeasurement[]): Promise<PostMeasurementResponse[]> => {
 	let index = 0;

--- a/packages/bot-utils/src/target-query.ts
+++ b/packages/bot-utils/src/target-query.ts
@@ -25,7 +25,7 @@ export function parseTargetQuery(cmd: string | undefined, args: string[]): Targe
         targetQuery.resolver = resolver;
     }
 
-    targetQuery.target = argsWithoutResolver[0] ? String(argsWithoutResolver[0]) : '';
+    targetQuery.target = argsWithoutResolver[0] ? fixTarget(cmd, String(argsWithoutResolver[0])) : '';
 
     if (argsWithoutResolver.length > 1) {
         if (argsWithoutResolver[1] === 'from') {
@@ -36,6 +36,18 @@ export function parseTargetQuery(cmd: string | undefined, args: string[]): Targe
     }
 
     return targetQuery;
+}
+
+// fix target if needed
+function fixTarget(cmd: string, text: string): string {
+    // remove http:// if it was added to the target and the command is not http
+    // it could have been added by mistake by the user, and auto added by slack in mentions
+    const httpPrefix = 'http://';
+    if (cmd !== 'http' && text.startsWith(httpPrefix)) {
+        return text.slice(httpPrefix.length);
+    }
+
+    return text;
 }
 
 export function findAndRemoveResolver(args: string[]): [string, string[]] {

--- a/packages/bot-utils/tests/target-query.test.ts
+++ b/packages/bot-utils/tests/target-query.test.ts
@@ -52,6 +52,26 @@ describe('Utils', () => {
             expect(q.from).toEqual('london');
             expect(q.resolver).toEqual('1.1.1.1');
         });
+
+        it('with http fixing', () => {
+            const cmd = 'ping';
+            const args = ['http://example.com', 'from', 'milano'];
+
+            const q: TargetQuery = parseTargetQuery(cmd, args);
+
+            expect(q.target).toEqual('example.com');
+            expect(q.from).toEqual('milano');
+        });
+
+        it('no http fixing if cmd is http', () => {
+            const cmd = 'http';
+            const args = ['http://example.com', 'from', 'milano'];
+
+            const q: TargetQuery = parseTargetQuery(cmd, args);
+
+            expect(q.target).toEqual('http://example.com');
+            expect(q.from).toEqual('milano');
+        });
     });
 
     describe('findAndRemoveResolver', () => {

--- a/packages/slack/src/mention.ts
+++ b/packages/slack/src/mention.ts
@@ -1,0 +1,12 @@
+
+
+export function parseCommandfromMention(text: string, botUserId: string): string {
+    const trimmedText = text.trim();
+    const expectedMention = `<@${botUserId}>`;
+    if (trimmedText.startsWith(expectedMention)) {
+        const urlRegex = /<([^>|]+)(?:\|[^>]+)?>/g;
+        return trimmedText.slice(expectedMention.length).replace(urlRegex, '$1').trim();
+    }
+
+    return '';
+}

--- a/packages/slack/src/tests/mention.test.ts
+++ b/packages/slack/src/tests/mention.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCommandfromMention } from '../mention';
+
+describe('Mention', () => {
+    describe('parseCommandfromMention', () => {
+        it('valid with url link', () => {
+            const text = '<@U052V9JLQ5C> http <http://yahoo.com|yahoo.com> --from france --limit 5';
+            const botUserId = 'U052V9JLQ5C';
+            const cmd = parseCommandfromMention(text, botUserId);
+            expect(cmd).to.equal('http http://yahoo.com --from france --limit 5');
+        });
+
+        it('valid with complex url link', () => {
+            const text = '<@U052V9JLQ5C> http <https://www.example.com:8080/my/path?x=abc&yz=defg|yahoo.com> --from france --limit 5';
+            const botUserId = 'U052V9JLQ5C';
+            const cmd = parseCommandfromMention(text, botUserId);
+            expect(cmd).to.equal('http https://www.example.com:8080/my/path?x=abc&yz=defg --from france --limit 5');
+        });
+
+        it('valid with host', () => {
+            const text = '<@U052V9JLQ5C> dns yahoo.com --from france --limit 5';
+            const botUserId = 'U052V9JLQ5C';
+            const cmd = parseCommandfromMention(text, botUserId);
+            expect(cmd).to.equal('dns yahoo.com --from france --limit 5');
+        });
+
+        it('valid with ip', () => {
+            const text = '<@U052V9JLQ5C> ping 1.2.3.4 --from france --limit 5';
+            const botUserId = 'U052V9JLQ5C';
+            const cmd = parseCommandfromMention(text, botUserId);
+            expect(cmd).to.equal('ping 1.2.3.4 --from france --limit 5');
+        });
+
+        it('wrong user id', () => {
+            const text = '<@U061X8OMS7D> ping <http://yahoo.com|yahoo.com> --from france --limit 5';
+            const botUserId = 'U052V9JLQ5C';
+            const cmd = parseCommandfromMention(text, botUserId);
+            expect(cmd).to.equal('');
+        });
+
+        it('text before mention', () => {
+            const text = 'some other text <@U052V9JLQ5C> ping <http://yahoo.com|yahoo.com> --from france --limit 5';
+            const botUserId = 'U052V9JLQ5C';
+            const cmd = parseCommandfromMention(text, botUserId);
+            expect(cmd).to.equal('');
+        });
+    });
+});

--- a/packages/slack/src/utils.ts
+++ b/packages/slack/src/utils.ts
@@ -86,4 +86,3 @@ export const postAPI = async (client: WebClient, payload: ChannelPayload, cmdTex
 		}
 	}
 };
-


### PR DESCRIPTION
Fixes #9 
Support `@globalping ...` syntax, similarly to `/globalping ...`

@jimaek to enable this, "Event subscriptions" need to be updated in the Slack API dashboard for the app:
- Go to the "Event Subscriptions" section
- Click on "Subscribe to bot events"
- Click on "Add Bot User Event"
- Find and add the event "app_mention"
- Click on "Save Changes"
- Because this change adds a new scope "app_mentions:read", the globalping app needs to be reinstalled by users to their workspaces for this change to take effect
