### PR TITLE
feat: discord - add auth and limits commands

### DIFF
--- a/packages/bot-utils/src/db.ts
+++ b/packages/bot-utils/src/db.ts
@@ -3,7 +3,8 @@ import knex, { type Knex } from 'knex';
 export type KnexClient = Knex;
 
 export enum Tables {
-	Installations = 'installations',
+	Installations = 'installations', // slack
+	DiscordUsers = 'discord_users',
 }
 
 export function initKnexClient (

--- a/packages/bot-utils/src/index.ts
+++ b/packages/bot-utils/src/index.ts
@@ -9,3 +9,4 @@ export * from './utils.js';
 export * from './help.js';
 export * from './response.js';
 export * from './db.js';
+export * from './oauth.js';

--- a/packages/bot-utils/src/types.ts
+++ b/packages/bot-utils/src/types.ts
@@ -1,3 +1,5 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+
 // Docs: https://globalping.io/docs/api.globalping.io
 
 export const ALLOWED_QUERY_TYPES = [
@@ -389,4 +391,10 @@ export interface AuthToken {
 	refresh_token: string;
 	expiry: number; // Unix timestamp
 	isAnonymous?: boolean;
+}
+
+export interface CustomRoute {
+	path: string;
+	method: string | string[];
+	handler: (req: IncomingMessage, res: ServerResponse) => void;
 }

--- a/packages/bot-utils/tests/oauth.test.ts
+++ b/packages/bot-utils/tests/oauth.test.ts
@@ -1,21 +1,19 @@
-import { AuthToken } from '@globalping/bot-utils';
-import { ParamsIncomingMessage } from '@slack/bolt/dist/receivers/ParamsIncomingMessage.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
 	AuthorizeError,
 	AuthorizeErrorType,
+	Config,
 	IntrospectionResponse,
 	OAuthClient,
-} from '../src/auth.js';
-import { AuthorizeSession, Installation } from '../src/db.js';
-import { Config } from '../src/types.js';
-import { mockDBClient, mockLogger, mockSlackClient } from './utils.js';
+} from '../src/oauth.js';
+import { mockDBClient, mockLogger } from './utils.js';
+import { AuthToken } from '../src/types.js';
 
 describe('Auth', () => {
 	const config: Config = {
 		serverHost: 'http://localhost',
-		dashboardUrl: 'http://dash.localhost',
+		authCallbackPath: '/oauth/callback',
 		authUrl: 'http://auth.localhost',
 		authClientId: 'client_id',
 		authClientSecret: 'client_secret',
@@ -23,14 +21,8 @@ describe('Auth', () => {
 
 	const loggerMock = mockLogger();
 	const dbClientMock = mockDBClient();
-	const slackClientMock = mockSlackClient();
 
-	const oauth: OAuthClient = new OAuthClient(
-		config,
-		loggerMock,
-		dbClientMock,
-		slackClientMock,
-	);
+	const oauth: OAuthClient = new OAuthClient(config, loggerMock, dbClientMock);
 
 	afterEach(() => {
 		vi.resetAllMocks();
@@ -43,11 +35,10 @@ describe('Auth', () => {
 			const threadTs = '123';
 			const installationId = 'I123';
 
-			const res = await oauth.Authorize({
-				installationId,
-				user_id: userId,
-				channel_id: channelId,
-				thread_ts: threadTs,
+			const res = await oauth.Authorize(installationId, {
+				userId,
+				channelId,
+				threadTs,
 			});
 
 			expect(dbClientMock.updateAuthorizeSession).toHaveBeenCalledWith(
@@ -68,6 +59,9 @@ describe('Auth', () => {
 			expect(url.searchParams.get('code_challenge')?.length).toBe(43);
 			expect(url.searchParams.get('code_challenge_method')).toBe('S256');
 			expect(url.searchParams.get('scope')).toBe('measurements');
+
+			expect(url.searchParams.get('redirect_uri')).toBe(config.serverHost + config.authCallbackPath);
+
 			const state = url.searchParams.get('state');
 			expect(state?.length).toBe(43 + 1 + installationId.length);
 			expect(state?.substring(43)).toBe('-' + installationId);
@@ -500,37 +494,12 @@ describe('Auth', () => {
 		});
 	});
 
-	describe('OnCallback', () => {
-		it('should exchange a new token, revoke the old token, and post a success message in slack', async () => {
-			const code = 'code';
-			const userId = 'U123';
-			const channelId = 'C123';
-			const threadTs = '123';
-			const installationId = 'I123';
-
+	describe('Exchange', () => {
+		it('should exchange the token', async () => {
 			const now = new Date();
+			const id = '123';
 
-			const token: AuthToken = {
-				access_token: 'tok3n',
-				refresh_token: 'refresh_tok3n',
-				expires_in: 3600,
-				token_type: 'Bearer',
-				expiry: now.getTime() / 1000 - 3600,
-			};
-
-			const authorizeSession: AuthorizeSession = {
-				callbackVerifier: 'callback',
-				exchangeVerifier: 'verifier',
-				userId,
-				channelId,
-				threadTs,
-			};
-
-			const installation = {
-				bot: { token: 'installation_token' },
-			} as Installation;
-
-			const newToken: AuthToken = {
+			const expectedToken: AuthToken = {
 				access_token: 'new_tok3n',
 				refresh_token: 'new_refresh_tok3n',
 				expires_in: 3600,
@@ -540,61 +509,41 @@ describe('Auth', () => {
 
 			vi.spyOn(Date, 'now').mockReturnValue(now.getTime());
 
-			vi.spyOn(
-				dbClientMock,
-				'getInstallationForAuthorization',
-			).mockResolvedValue({
-				token,
-				session: authorizeSession,
-				installation,
-			});
-
-			const exchangeFetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+			const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
 				ok: true,
 				status: 200,
-				json: async () => newToken,
+				json: async () => expectedToken,
 			} as Response);
 
-			const revokeFetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-			} as Response);
+			const err = await oauth.Exchange('cod3', 'verifi3r', id);
 
-			const req = {
-				url: `/oauth/callback?code=${code}&state=${authorizeSession.callbackVerifier}-${installationId}`,
-			} as ParamsIncomingMessage;
-			const res = {
-				writeHead: vi.fn(),
-				end: vi.fn(),
-			} as any;
+			expect(err).toBeNull();
 
-			await oauth.OnCallback(req, res);
+			expect(dbClientMock.updateToken).toHaveBeenCalledWith(id, expectedToken);
 
-			expect(dbClientMock.getInstallationForAuthorization).toHaveBeenCalledWith(installationId);
-
-			expect(dbClientMock.updateAuthorizeSession).toHaveBeenCalledWith(
-				installationId,
-				null,
-			);
-
-			expect(dbClientMock.updateToken).toHaveBeenCalledWith(
-				installationId,
-				newToken,
-			);
-
-			expect(exchangeFetchSpy).toHaveBeenCalledWith(
-				`${config.authUrl}/oauth/token`,
-				{
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/x-www-form-urlencoded',
-						'Content-Length': '173',
-					},
-					body: 'client_id=client_id&client_secret=client_secret&code=code&code_verifier=verifier&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%2Fslack%2Foauth%2Fcallback',
+			expect(fetchSpy).toHaveBeenCalledWith(`${config.authUrl}/oauth/token`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'Content-Length': '165',
 				},
-			);
+				body: 'client_id=client_id&client_secret=client_secret&code=cod3&code_verifier=verifi3r&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%2Foauth%2Fcallback',
+			});
+		});
+	});
 
-			expect(revokeFetchSpy).toHaveBeenCalledWith(
+	describe('RevokeToken', () => {
+		it('should revoke the token', async () => {
+			const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+				ok: true,
+				status: 200,
+			} as Response);
+
+			const err = await oauth.RevokeToken('refresh_tok3n');
+
+			expect(err).toBeNull();
+
+			expect(fetchSpy).toHaveBeenCalledWith(
 				`${config.authUrl}/oauth/token/revoke`,
 				{
 					method: 'POST',
@@ -605,92 +554,6 @@ describe('Auth', () => {
 					body: 'token=refresh_tok3n',
 				},
 			);
-
-			expect(slackClientMock.chat.postEphemeral).toHaveBeenCalledWith({
-				token: installation?.bot?.token,
-				text: 'Success! You are now authenticated.',
-				user: userId,
-				channel: channelId,
-				thread_ts: threadTs,
-			});
-
-			expect(res.writeHead).toHaveBeenCalledWith(302, {
-				Location: `${config.dashboardUrl}/authorize/success`,
-			});
-
-			expect(res.end).toHaveBeenCalled();
-		});
-
-		it('should redirect to the error page - callback verifier does not match', async () => {
-			const code = 'code';
-			const userId = 'U123';
-			const channelId = 'C123';
-			const threadTs = '123';
-			const installationId = 'I123';
-
-			const now = new Date();
-
-			const token: AuthToken = {
-				access_token: 'tok3n',
-				refresh_token: 'refresh_tok3n',
-				expires_in: 3600,
-				token_type: 'Bearer',
-				expiry: now.getTime() / 1000 - 3600,
-			};
-
-			const authorizeSession: AuthorizeSession = {
-				callbackVerifier: 'callback',
-				exchangeVerifier: 'verifier',
-				userId,
-				channelId,
-				threadTs,
-			};
-
-			const installation = {
-				bot: { token: 'installation_token' },
-			} as Installation;
-
-			vi.spyOn(Date, 'now').mockReturnValue(now.getTime());
-
-			vi.spyOn(
-				dbClientMock,
-				'getInstallationForAuthorization',
-			).mockResolvedValue({
-				token,
-				session: {
-					...authorizeSession,
-					callbackVerifier: 'wrong',
-				},
-				installation,
-			});
-
-			const fetchSpy = vi.spyOn(global, 'fetch');
-
-			const req = {
-				url: `/oauth/callback?code=${code}&state=${authorizeSession.callbackVerifier}-${installationId}`,
-			} as ParamsIncomingMessage;
-			const res = {
-				writeHead: vi.fn(),
-				end: vi.fn(),
-			} as any;
-
-			await oauth.OnCallback(req, res);
-
-			expect(dbClientMock.getInstallationForAuthorization).toHaveBeenCalledWith(installationId);
-
-			expect(dbClientMock.updateAuthorizeSession).toHaveBeenCalledTimes(0);
-
-			expect(dbClientMock.updateToken).toHaveBeenCalledTimes(0);
-
-			expect(fetchSpy).toHaveBeenCalledTimes(0);
-
-			expect(slackClientMock.chat.postEphemeral).toHaveBeenCalledTimes(0);
-
-			expect(res.writeHead).toHaveBeenCalledWith(302, {
-				Location: `${config.dashboardUrl}/authorize/error`,
-			});
-
-			expect(res.end).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/bot-utils/tests/response.test.ts
+++ b/packages/bot-utils/tests/response.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	fullResultsFooter,
+	getMoreCreditsRequiredAuthError,
+	getMoreCreditsRequiredNoAuthError,
+	getNoCreditsAuthError,
+	getNoCreditsNoAuthError,
 	LinkBlockType,
 	responseHeader,
 	shareMessageFooter,
@@ -77,6 +81,34 @@ describe('Response', () => {
 			};
 			const text = responseHeader(pingResult, 'tag-1', boldSeparator);
 			expect(text).to.equal('> *Atlanta (GA), US, NA, My Network (AS12345), (tag-1)*\n');
+		});
+	});
+
+	describe('getMoreCreditsRequiredAuthError', () => {
+		it('should return correct error', () => {
+			const error = getMoreCreditsRequiredAuthError(5, 2, 300);
+			expect(error).toEqual(new Error('You only have 2 credits remaining, and 5 were required. Try requesting fewer probes or wait 5 minutes for the rate limit to reset. You can get higher limits by sponsoring us or hosting probes.'));
+		});
+	});
+
+	describe('getNoCreditsAuthError', () => {
+		it('should return correct error', () => {
+			const error = getNoCreditsAuthError(60);
+			expect(error).toEqual(new Error('You have run out of credits for this session. You can wait 1 minute for the rate limit to reset or get higher limits by sponsoring us or hosting probes.'));
+		});
+	});
+
+	describe('getMoreCreditsRequiredNoAuthError', () => {
+		it('should return correct error', () => {
+			const error = getMoreCreditsRequiredNoAuthError(2, 1, 245);
+			expect(error).toEqual(new Error('You only have 1 credit remaining, and 2 were required. Try requesting fewer probes or wait 4 minutes for the rate limit to reset. You can get higher limits by creating an account. Sign up at https://globalping.io'));
+		});
+	});
+
+	describe('getNoCreditsNoAuthError', () => {
+		it('should return correct error', () => {
+			const error = getNoCreditsNoAuthError(10);
+			expect(error).toEqual(new Error('You have run out of credits for this session. You can wait 10 seconds for the rate limit to reset or get higher limits by creating an account. Sign up at https://globalping.io'));
 		});
 	});
 });

--- a/packages/bot-utils/tests/utils.ts
+++ b/packages/bot-utils/tests/utils.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+
+import { DBClient } from '../src/oauth.js';
+import { Logger } from '../src/logger.js';
+
+export const mockDBClient = (): DBClient => ({
+	getToken: vi.fn(),
+	updateToken: vi.fn(),
+	updateAuthorizeSession: vi.fn(),
+}) as any;
+
+export const mockLogger = (): Logger => ({
+	info: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+}) as any;

--- a/packages/discord/src/bot.ts
+++ b/packages/discord/src/bot.ts
@@ -1,4 +1,5 @@
 import {
+	AuthSubcommand,
 	buildPostMeasurements,
 	Flags,
 	formatAPIError,
@@ -7,16 +8,25 @@ import {
 	getMeasurement,
 	getTag,
 	HelpTexts,
+	KnexClient,
 	LinkBlockType,
 	Logger,
 	Measurement,
 	MeasurementCreate,
 	MeasurementCreateResponse,
+	OAuthClient,
 	postMeasurement,
 	responseHeader,
 	responseText,
 	shareMessageFooter,
 	throwArgError,
+	getLimitsOutput,
+	AuthorizeErrorType,
+	AuthToken,
+	AuthorizeError,
+	PostError,
+	getTooManyRequestsError,
+	CustomRoute,
 } from '@globalping/bot-utils';
 import {
 	APIEmbed,
@@ -27,15 +37,44 @@ import {
 	GatewayIntentBits,
 	inlineCode,
 	Interaction,
+	MessageFlags,
+	PermissionFlagsBits,
+	PermissionsBitField,
+	TextChannel,
 	userMention,
 } from 'discord.js';
 
 import { getHelpForCommand } from './utils.js';
+import { Config } from './types.js';
+import { DBClient, AuthorizeSession } from './db.js';
+import { IncomingMessage, ServerResponse } from 'node:http';
 
-export const initBot = (logger: Logger) => {
+export const initBot = (
+	config: Config,
+	logger: Logger,
+	knex: KnexClient,
+	routes: CustomRoute[],
+) => {
 	const client = new Client({ intents: [ GatewayIntentBits.Guilds ] });
 
-	const bot = new Bot(logger, postMeasurement, getMeasurement);
+	const db = new DBClient(knex, logger);
+
+	const oauth = new OAuthClient(config, logger, db);
+
+	const bot = new Bot(
+		logger,
+		config,
+		db,
+		postMeasurement,
+		getMeasurement,
+		oauth,
+		client,
+	);
+	routes.push({
+		path: config.authCallbackPath,
+		method: [ 'GET' ],
+		handler: (req, res) => bot.OnAuthCallback(req, res),
+	});
 
 	client.on('ready', () => logger.info('Discord bot is online'));
 	client.on('debug', m => logger.debug(m));
@@ -53,19 +92,17 @@ export class Bot {
 
 	constructor (
 		private logger: Logger,
+		private config: Config,
+		private dbClient: DBClient,
 		private postMeasurement: (
 			opts: MeasurementCreate,
 			token?: string,
 		) => Promise<MeasurementCreateResponse>,
 		private getMeasurement: (id: string) => Promise<Measurement>,
+		private oauth: OAuthClient,
+		private discord: Client,
 	) {
-		this.help = generateHelp(
-			'**',
-			'/globalping',
-			new Set([ 'auth', 'limits' ]),
-			4,
-			1,
-		);
+		this.help = generateHelp('**', '/globalping', undefined, 4, 1);
 	}
 
 	async HandleInteraction (interaction: Interaction<CacheType>) {
@@ -79,9 +116,7 @@ export class Bot {
 			return;
 		}
 
-		await interaction.deferReply();
-
-		let txtCommand;
+		let cmdText;
 
 		try {
 			const flags = this.getFlags(interaction);
@@ -91,12 +126,38 @@ export class Bot {
 					flags.help = 'help';
 				}
 
-				await interaction.editReply(getHelpForCommand(flags.help, '', this.help));
+				await interaction.reply({
+					content: getHelpForCommand(flags.help, flags.target, this.help),
+					flags: MessageFlags.Ephemeral,
+				});
 
 				return;
 			}
 
-			txtCommand = this.expandCommand(flags);
+			cmdText = this.expandCommand(flags);
+
+			if (flags.cmd === 'auth') {
+				await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+				switch (flags.target) {
+					case AuthSubcommand.Login:
+						await this.authLogin(interaction);
+						return;
+					case AuthSubcommand.Logout:
+						await this.authLogout(interaction);
+						return;
+					case AuthSubcommand.Status:
+						await this.authStatus(interaction);
+						return;
+				}
+			}
+
+			if (flags.cmd === 'limits') {
+				await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+				await this.limits(interaction);
+				return;
+			}
 
 			if (!flags.from) {
 				flags.from = 'world';
@@ -106,35 +167,399 @@ export class Bot {
 				flags.limit = 1;
 			}
 
-			const measurementResponse = await this.postMeasurement(buildPostMeasurements(flags));
-			const res = await this.getMeasurement(measurementResponse.id);
+			await interaction.deferReply();
 
-			const embeds = this.formatMeasurementResponse(res, flags);
-
-			await interaction.editReply({
-				content: `${userMention(user.id)}, here are the results for ${inlineCode(txtCommand)}`,
-				embeds,
-			});
+			await this.createMeasurement(interaction, flags, cmdText);
 		} catch (error) {
 			this.logger.error(`Error processing request`, {
 				error,
-				command: txtCommand,
+				command: cmdText,
 			});
 
-			await interaction.editReply(`${userMention(user.id)}, there was an error processing your request for ${inlineCode(txtCommand ?? 'help')}
-${formatAPIError(error)}`);
+			const errorMsg = `${userMention(user.id)}, there was an error processing your request for ${inlineCode(cmdText ?? 'help')}
+${formatAPIError(error)}`;
+
+			if (interaction.deferred) {
+				await interaction.editReply(errorMsg);
+			} else {
+				await interaction.reply(errorMsg);
+			}
 		}
+	}
+
+	async OnAuthCallback (req: IncomingMessage, res: ServerResponse) {
+		const url = new URL(req.url || '', this.config.serverHost);
+		const callbackError = url.searchParams.get('error');
+		const errorDescription = url.searchParams.get('error_description');
+		const code = url.searchParams.get('code');
+		const state = url.searchParams.get('state');
+
+		if (!state) {
+			this.logger.error('/oauth/callback missing state', { callbackError });
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		const separatorIndex = state.indexOf('-');
+		const callbackVerifier = state.substring(0, separatorIndex);
+		const id = state.substring(separatorIndex + 1);
+
+		let oldToken: AuthToken | null;
+		let session: AuthorizeSession | null;
+
+		try {
+			const data = await this.dbClient.getDataForAuthorization(id);
+			oldToken = data.token;
+			session = data.session;
+		} catch {
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		if (!session) {
+			this.logger.error('/oauth/callback missing session', { id });
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		if (callbackVerifier !== session.callbackVerifier) {
+			this.logger.error('/oauth/callback invalid verifier', {
+				id,
+			});
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		try {
+			// Delete session
+			await this.dbClient.updateAuthorizeSession(id, null);
+		} catch (error) {
+			this.logger.error('/oauth/callback failed to delete session', error);
+		}
+
+		if (callbackError || !code) {
+			try {
+				const user = this.discord.users.cache.get(session.userId);
+
+				if (user) {
+					await user.send(`Authentication failed: ${callbackError}: ${errorDescription}`);
+				}
+			} catch (error) {
+				this.logger.error('/oauth/callback failed to post ephemeral', error);
+			}
+
+			this.logger.error('/oauth/callback failed', {
+				error: callbackError,
+				errorDescription,
+				code,
+				id,
+			});
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		let exchangeError: AuthorizeError | null;
+
+		try {
+			exchangeError = await this.oauth.Exchange(
+				code,
+				session.exchangeVerifier,
+				id,
+			);
+
+			// Revoke old token if exists
+			if (!exchangeError && oldToken && oldToken.refresh_token) {
+				try {
+					await this.oauth.RevokeToken(oldToken.refresh_token);
+				} catch (error) {
+					this.logger.error('/oauth/callback failed to revoke token', {
+						id,
+						error,
+					});
+				}
+			}
+		} catch {
+			exchangeError = {
+				error: AuthorizeErrorType.InternalError,
+				error_description: 'Failed to exchange code',
+			};
+		}
+
+		if (exchangeError) {
+			this.logger.error('/oauth/callback failed', exchangeError);
+		}
+
+		try {
+			if (exchangeError) {
+				// We can't send ephemeral messages to users directly,
+				// so we send a DM if an error occurs.
+				const user = this.discord.users.cache.get(session.userId);
+
+				if (user) {
+					await user.send(`Authentication failed: ${exchangeError.error}: ${exchangeError.error_description}`);
+				}
+			} else {
+				const channel = this.discord.channels.cache.get(session.channelId) as TextChannel;
+
+				if (channel) {
+					await channel.send('Success! You are now authenticated.');
+				}
+			}
+		} catch (error) {
+			this.logger.error('/oauth/callback failed to reply to user', error);
+		}
+
+		res.writeHead(302, {
+			Location:
+				this.config.dashboardUrl
+				+ (exchangeError ? '/authorize/error' : '/authorize/success'),
+		});
+
+		res.end();
+	}
+
+	private async createMeasurement (
+		interaction: ChatInputCommandInteraction,
+		flags: Flags,
+		cmdText: string,
+	) {
+		const id = this.getIdFromInteraction(interaction);
+		const token = await this.oauth.GetToken(id);
+
+		let measurementResponse: MeasurementCreateResponse;
+
+		try {
+			measurementResponse = await this.postMeasurement(
+				buildPostMeasurements(flags),
+				token?.access_token,
+			);
+		} catch (error) {
+			if (error instanceof PostError) {
+				const { statusCode, headers } = error.response;
+
+				// Unauthorized or Forbidden
+				if ((statusCode === 401 || statusCode === 403) && token) {
+					const errMsg = await this.oauth.TryToRefreshToken(id, token);
+
+					if (errMsg) {
+						throw new Error(errMsg);
+					}
+				}
+
+				// Too many requests
+				if (statusCode === 429) {
+					throw getTooManyRequestsError(headers, token);
+				}
+			}
+
+			throw error;
+		}
+
+		const res = await this.getMeasurement(measurementResponse.id);
+
+		const embeds = this.formatMeasurementResponse(res, flags);
+
+		await interaction.editReply({
+			content: `${userMention(interaction.user.id)}, here are the results for ${inlineCode(cmdText)}`,
+			embeds,
+		});
+	}
+
+	private async authLogin (interaction: ChatInputCommandInteraction) {
+		if (!await this.canUseAuthCommand(interaction)) {
+			return;
+		}
+
+		const id = this.getIdFromInteraction(interaction);
+
+		const res = await this.oauth.Authorize(id, {
+			userId: interaction.user.id,
+			channelId: interaction.channelId,
+		});
+
+		let text = `Please [click here](${res.url}) to authenticate.`;
+
+		if (interaction.inGuild()) {
+			text
+				+= '\n\n**Note:** The login is set for the server. Once logged in, account credits are shared between all users in the server.';
+		}
+
+		await interaction.editReply({
+			embeds: [
+				{
+					description: text,
+				},
+			],
+		});
+	}
+
+	private async authStatus (interaction: ChatInputCommandInteraction) {
+		if (!await this.canUseAuthCommand(interaction)) {
+			return;
+		}
+
+		const id = this.getIdFromInteraction(interaction);
+
+		const [ introspection, error ] = await this.oauth.Introspect(id);
+		let text = '';
+
+		if (error) {
+			text
+				= error.error === AuthorizeErrorType.NotAuthorized
+					? 'Not logged in.'
+					: `${error.error}: ${error.error_description}`;
+		}
+
+		text
+			= introspection && introspection.active && introspection.username
+				? `Logged in as ${introspection?.username}.`
+				: 'Not logged in.';
+
+		await interaction.editReply({
+			content: text,
+		});
+	}
+
+	private async authLogout (interaction: ChatInputCommandInteraction) {
+		if (!await this.canUseAuthCommand(interaction)) {
+			return;
+		}
+
+		const id = this.getIdFromInteraction(interaction);
+
+		const error = await this.oauth.Logout(id);
+		let text = '';
+		text = error
+			? `${error.error}: ${error.error_description}`
+			: 'You are now logged out.';
+
+		await interaction.editReply({
+			content: text,
+		});
+	}
+
+	private async limits (interaction: ChatInputCommandInteraction) {
+		const id = this.getIdFromInteraction(interaction);
+
+		const [ introspection, error ] = await this.oauth.Introspect(id);
+
+		if (!introspection) {
+			await interaction.editReply({
+				content: `${error?.error}: ${error?.error_description}`,
+			});
+
+			return;
+		}
+
+		const [ limits, limitsError ] = await this.oauth.Limits(id);
+
+		if (!limits) {
+			await interaction.editReply({
+				content: `${limitsError?.type}: ${limitsError?.message}`,
+			});
+
+			return;
+		}
+
+		await interaction.editReply({
+			content: getLimitsOutput(limits, introspection),
+		});
+	}
+
+	private getIdFromInteraction (interaction: ChatInputCommandInteraction): string {
+		if (interaction.inGuild()) {
+			return 'G' + interaction.guildId;
+		}
+
+		return 'U' + interaction.user.id;
+	}
+
+	private async canUseAuthCommand (interaction: ChatInputCommandInteraction): Promise<boolean> {
+		if (!interaction.inGuild()) {
+			return true;
+		}
+
+		const canAuthenticate = (
+			interaction.member.permissions as PermissionsBitField
+		).has(PermissionFlagsBits.Administrator);
+
+		if (!canAuthenticate) {
+			await interaction.editReply({
+				content: 'Only administrators can use this command.',
+			});
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private getFlags (interaction: ChatInputCommandInteraction): Flags {
 		const cmd = interaction.options.getSubcommand();
-		const helpVal
-			= interaction.options.getString('command')
-			?? (cmd === 'help' ? 'help' : undefined);
+
+		if (interaction.options.getSubcommandGroup() === 'auth') {
+			return {
+				cmd: 'auth',
+				target: cmd,
+				from: '',
+				limit: undefined as unknown as number,
+			};
+		}
+
+		if (cmd === 'help') {
+			let help = interaction.options.getString('command') ?? 'help';
+			let target = '';
+
+			if (help.startsWith('auth ')) {
+				target = help.split(' ')[1];
+				help = 'auth';
+			}
+
+			return {
+				cmd,
+				target,
+				from: '',
+				limit: undefined as unknown as number,
+				help,
+			};
+		}
+
+		if (cmd === 'limits') {
+			return {
+				cmd,
+				target: '',
+				from: '',
+				limit: undefined as unknown as number,
+			};
+		}
 
 		const target
 			= interaction.options.getString('target')
-			?? (helpVal ? '' : throwArgError(undefined, 'target', 'jsdelivr.com'));
+			?? throwArgError(undefined, 'target', 'jsdelivr.com');
 		const from = interaction.options.getString('from') ?? undefined;
 		const rawHeader
 			= interaction.options
@@ -164,7 +589,6 @@ ${formatAPIError(error)}`);
 			share: interaction.options.getBoolean('share') ?? undefined,
 			latency: interaction.options.getBoolean('latency') ?? undefined,
 			full: interaction.options.getBoolean('full') ?? undefined,
-			help: helpVal,
 		};
 	}
 

--- a/packages/discord/src/db.ts
+++ b/packages/discord/src/db.ts
@@ -1,0 +1,125 @@
+import { AuthToken, Logger, KnexClient, Tables } from '@globalping/bot-utils';
+
+export interface AuthorizeSession {
+	callbackVerifier: string;
+	exchangeVerifier: string;
+	userId: string;
+	channelId: string;
+}
+
+export class DBClient {
+	constructor (
+		private knex: KnexClient,
+		private logger: Logger,
+	) {}
+
+	async getToken (id: string) {
+		try {
+			const res = await this.knex
+				.table(Tables.DiscordUsers)
+				.select('token', 'anonymous_token')
+				.where('id', id)
+				.first();
+
+			if (!res) {
+				return null;
+			}
+
+			if (res.token) {
+				return JSON.parse(res.token) as AuthToken;
+			}
+
+			if (res.anonymous_token) {
+				return JSON.parse(res.anonymous_token) as AuthToken;
+			}
+
+			return null;
+		} catch (error) {
+			const err = new Error(`Failed to get token: ${error}`);
+			this.logger.error(err.message, error);
+			throw err;
+		}
+	}
+
+	async updateToken (id: string, token: AuthToken | null) {
+		try {
+			// Note: The anonymous token is kept separately and not
+			// deleted to make sure the rate limits are not exceeded
+			// when the user signs in/out or the bot is re-installed.
+			const update: {
+				token?: string | null;
+				anonymous_token?: string | null;
+			} = {};
+
+			if (token?.isAnonymous) {
+				update.anonymous_token = JSON.stringify(token);
+			} else {
+				update.token = token ? JSON.stringify(token) : null;
+			}
+
+			await this.knex
+				.table(Tables.DiscordUsers)
+				.where('id', id)
+				.update(update as never);
+
+			this.logger.debug('Token set', { id });
+		} catch (error) {
+			const err = new Error(`Failed to set token: ${error}`);
+			this.logger.error(err.message, error);
+			throw err;
+		}
+	}
+
+	async updateAuthorizeSession (
+		id: string,
+		authorizeSesssion: AuthorizeSession | null,
+	) {
+		try {
+			await this.knex
+				.table(Tables.DiscordUsers)
+				.insert({
+					id,
+					authorize_session: authorizeSesssion
+						? JSON.stringify(authorizeSesssion)
+						: null,
+				})
+				.onConflict('id')
+				.merge();
+		} catch (error) {
+			const err = new Error(`Failed to set authorize session: ${error}`);
+			this.logger.error(err.message, error);
+			throw err;
+		}
+	}
+
+	async getDataForAuthorization (id: string) {
+		try {
+			const res = await this.knex
+				.table(Tables.DiscordUsers)
+				.select('token', 'authorize_session')
+				.where('id', id)
+				.first();
+
+			if (!res) {
+				return {
+					token: null,
+					session: null,
+				};
+			}
+
+			// Note: When upgrading the MySQL version, the JSON.parse() call may not be needed
+			const token = res.token ? JSON.parse(res.token) : null;
+			const session = res.authorize_session
+				? JSON.parse(res.authorize_session)
+				: null;
+			return {
+				token,
+				session,
+			};
+		} catch (error) {
+			const err = new Error(`Failed to get authorize session: ${error}`);
+			this.logger.error(err.message, error);
+			throw err;
+		}
+	}
+}

--- a/packages/discord/src/deploy-commands.ts
+++ b/packages/discord/src/deploy-commands.ts
@@ -7,14 +7,15 @@ import {
 	ALLOWED_MTR_PROTOCOLS,
 	ALLOWED_QUERY_TYPES,
 	ALLOWED_TRACE_PROTOCOLS,
+	AuthSubcommand,
 } from '@globalping/bot-utils';
 import { Routes, SlashCommandBuilder } from 'discord.js';
-import { Config } from './types.js';
+import { DeployCommandsConfig } from './types.js';
 
 const choiceMap = (arr: string[]) => arr.map(item => ({ name: item, value: item }));
 
 // Only needs to be run once whenever bot is registered with server
-export const deployCommands = (config: Config) => {
+export const deployCommands = (config: DeployCommandsConfig) => {
 	const commands = [
 		new SlashCommandBuilder()
 			.setName('globalping')
@@ -213,6 +214,23 @@ export const deployCommands = (config: Config) => {
 					.setName('full')
 					.setDescription('Output full response')
 					.setRequired(false)))
+			// auth
+			.addSubcommandGroup(group => group
+				.setName('auth')
+				.setDescription('Authenticate with the Globalping API')
+				.addSubcommand(subcommand => subcommand
+					.setName(AuthSubcommand.Login)
+					.setDescription('Log in to your Globalping account'))
+				.addSubcommand(subcommand => subcommand
+					.setName(AuthSubcommand.Logout)
+					.setDescription('Log out from your Globalping account'))
+				.addSubcommand(subcommand => subcommand
+					.setName(AuthSubcommand.Status)
+					.setDescription('Check the current authentication status')))
+			// limits
+			.addSubcommand(subcommand => subcommand
+				.setName('limits')
+				.setDescription('Show the current rate limits'))
 			// help
 			.addSubcommand(subcommand => subcommand
 				.setName('help')
@@ -221,7 +239,13 @@ export const deployCommands = (config: Config) => {
 					.setName('command')
 					.setDescription('Command to get help for')
 					.setRequired(false)
-					.addChoices(...choiceMap([ ...ALLOWED_QUERY_TYPES ])))),
+					.addChoices(...choiceMap([
+						...ALLOWED_QUERY_TYPES,
+						'auth ' + AuthSubcommand.Login,
+						'auth ' + AuthSubcommand.Logout,
+						'auth ' + AuthSubcommand.Status,
+						'limits',
+					])))),
 	].map(command => command.toJSON());
 
 	const rest = new REST({ version: '10' }).setToken(config.discordToken);

--- a/packages/discord/src/types.ts
+++ b/packages/discord/src/types.ts
@@ -1,4 +1,15 @@
-export interface Config {
+export interface DeployCommandsConfig {
 	discordToken: string;
 	discordAppId: string;
+}
+
+export interface Config {
+	serverHost: string;
+
+	apiUrl: string;
+	dashboardUrl: string;
+	authUrl: string;
+	authClientId: string;
+	authClientSecret: string;
+	authCallbackPath: string;
 }

--- a/packages/discord/src/utils.ts
+++ b/packages/discord/src/utils.ts
@@ -1,4 +1,4 @@
-import { HelpTexts } from '@globalping/bot-utils';
+import { AuthSubcommand, HelpTexts } from '@globalping/bot-utils';
 
 export const getHelpForCommand = (
 	cmd: string,
@@ -16,6 +16,21 @@ export const getHelpForCommand = (
 			return help.ping;
 		case 'traceroute':
 			return help.traceroute;
+
+		case 'auth':
+			switch (target) {
+				case AuthSubcommand.Login:
+					return help.auth_login;
+				case AuthSubcommand.Logout:
+					return help.auth_logout;
+				case AuthSubcommand.Status:
+					return help.auth_status;
+				default:
+					return help.auth;
+			}
+
+		case 'limits':
+			return help.limits;
 
 		case undefined:
 		case '':

--- a/packages/discord/tests/bot.test.ts
+++ b/packages/discord/tests/bot.test.ts
@@ -1,5 +1,10 @@
-import { generateHelp, HttpProbeResult } from '@globalping/bot-utils';
-import { codeBlock } from 'discord.js';
+import {
+	AuthToken,
+	CreateLimitType,
+	generateHelp,
+	HttpProbeResult,
+} from '@globalping/bot-utils';
+import { codeBlock, MessageFlags } from 'discord.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Bot } from '../src/bot.js';
 import {
@@ -8,11 +13,17 @@ import {
 	getDefaultMtrResponse,
 	getDefaultPingResponse,
 	getDefaultTracerouteResponse,
+	mockAuthClient,
+	mockDBClient,
+	mockDiscordClient,
 	mockDiscordInteraction,
 	mockGetMeasurement,
 	mockLogger,
 	mockPostMeasurement,
 } from './utils.js';
+import { Config } from '../src/types.js';
+import { AuthorizeSession } from '../src/db.js';
+import { IncomingMessage } from 'node:http';
 
 describe('Bot', () => {
 	afterEach(() => {
@@ -22,20 +33,30 @@ describe('Bot', () => {
 	const discordMessageLimit = 2000;
 
 	const loggerMock = mockLogger();
+	const dbClientMock = mockDBClient();
+	const oauthClientMock = mockAuthClient();
 	const postMeasurementMock = mockPostMeasurement();
 	const getMeasurementMock = mockGetMeasurement();
+	const discordClientMock = mockDiscordClient();
 
 	const interactionMock = mockDiscordInteraction();
 
-	const expectedHelpTexts = generateHelp(
-		'**',
-		'/globalping',
-		new Set([ 'auth', 'limits' ]),
-		4,
-		1,
-	);
+	const expectedHelpTexts = generateHelp('**', '/globalping', undefined, 4, 1);
+	const configMock = {
+		serverHost: 'http://localhost',
+		dashboardUrl: 'http://dash.localhost',
+		authUrl: 'http://auth.localhost',
+	};
 
-	const bot = new Bot(loggerMock, postMeasurementMock, getMeasurementMock);
+	const bot = new Bot(
+		loggerMock,
+		configMock as Config,
+		dbClientMock,
+		postMeasurementMock,
+		getMeasurementMock,
+		oauthClientMock,
+		discordClientMock,
+	);
 
 	describe('HandleInteraction', () => {
 		it('should handle the command - /globalping ping', async () => {
@@ -46,10 +67,15 @@ describe('Bot', () => {
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'ping',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
 			} as any;
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
 
 			postMeasurementMock.mockResolvedValue({
 				id: 'm345ur3m3nt',
@@ -63,14 +89,19 @@ describe('Bot', () => {
 
 			expect(interactionMock.deferReply).toHaveBeenCalled();
 
-			expect(postMeasurementMock).toHaveBeenCalledWith({
-				type: 'ping',
-				target: 'google.com',
-				inProgressUpdates: false,
-				limit: 1,
-				locations: [{ magic: 'world' }],
-				measurementOptions: {},
-			});
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith('G654');
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'ping',
+					target: 'google.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'world' }],
+					measurementOptions: {},
+				},
+				'tok3n',
+			);
 
 			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
 
@@ -101,10 +132,15 @@ describe('Bot', () => {
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'dns',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
 			} as any;
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
 
 			postMeasurementMock.mockResolvedValue({
 				id: 'm345ur3m3nt',
@@ -118,16 +154,21 @@ describe('Bot', () => {
 
 			expect(interactionMock.deferReply).toHaveBeenCalled();
 
-			expect(postMeasurementMock).toHaveBeenCalledWith({
-				type: 'dns',
-				target: 'google.com',
-				inProgressUpdates: false,
-				limit: 1,
-				locations: [{ magic: 'Berlin' }],
-				measurementOptions: {
-					resolver: '1.1.1.1',
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith('G654');
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'dns',
+					target: 'google.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'Berlin' }],
+					measurementOptions: {
+						resolver: '1.1.1.1',
+					},
 				},
-			});
+				'tok3n',
+			);
 
 			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
 
@@ -162,10 +203,15 @@ describe('Bot', () => {
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'http',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
 			} as any;
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
 
 			postMeasurementMock.mockResolvedValue({
 				id: 'm345ur3m3nt',
@@ -179,22 +225,27 @@ describe('Bot', () => {
 
 			expect(interactionMock.deferReply).toHaveBeenCalled();
 
-			expect(postMeasurementMock).toHaveBeenCalledWith({
-				type: 'http',
-				target: 'jsdelivr.com',
-				inProgressUpdates: false,
-				limit: 1,
-				locations: [{ magic: 'world' }],
-				measurementOptions: {
-					port: 443,
-					protocol: 'HTTPS',
-					request: {
-						host: 'www.jsdelivr.com',
-						path: '/package/npm/test',
-						query: 'nav=stats',
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith('G654');
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'http',
+					target: 'jsdelivr.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'world' }],
+					measurementOptions: {
+						port: 443,
+						protocol: 'HTTPS',
+						request: {
+							host: 'www.jsdelivr.com',
+							path: '/package/npm/test',
+							query: 'nav=stats',
+						},
 					},
 				},
-			});
+				'tok3n',
+			);
 
 			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
 
@@ -230,10 +281,15 @@ describe('Bot', () => {
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'http',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
 			} as any;
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
 
 			postMeasurementMock.mockResolvedValue({
 				id: 'm345ur3m3nt',
@@ -247,17 +303,22 @@ describe('Bot', () => {
 
 			expect(interactionMock.deferReply).toHaveBeenCalled();
 
-			expect(postMeasurementMock).toHaveBeenCalledWith({
-				type: 'http',
-				target: 'jsdelivr.com',
-				inProgressUpdates: false,
-				limit: 1,
-				locations: [{ magic: 'world' }],
-				measurementOptions: {
-					protocol: 'HTTPS',
-					request: {},
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith('G654');
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'http',
+					target: 'jsdelivr.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'world' }],
+					measurementOptions: {
+						protocol: 'HTTPS',
+						request: {},
+					},
 				},
-			});
+				'tok3n',
+			);
 
 			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
 
@@ -299,10 +360,15 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'mtr',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
 			} as any;
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
 
 			postMeasurementMock.mockResolvedValue({
 				id: 'm345ur3m3nt',
@@ -316,14 +382,19 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			expect(interactionMock.deferReply).toHaveBeenCalled();
 
-			expect(postMeasurementMock).toHaveBeenCalledWith({
-				type: 'mtr',
-				target: 'google.com',
-				inProgressUpdates: false,
-				limit: 1,
-				locations: [{ magic: 'world' }],
-				measurementOptions: {},
-			});
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith('G654');
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'mtr',
+					target: 'google.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'world' }],
+					measurementOptions: {},
+				},
+				'tok3n',
+			);
 
 			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
 
@@ -356,10 +427,15 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'traceroute',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
 			} as any;
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
 
 			postMeasurementMock.mockResolvedValue({
 				id: 'm345ur3m3nt',
@@ -373,14 +449,19 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			expect(interactionMock.deferReply).toHaveBeenCalled();
 
-			expect(postMeasurementMock).toHaveBeenCalledWith({
-				type: 'traceroute',
-				target: 'google.com',
-				inProgressUpdates: false,
-				limit: 1,
-				locations: [{ magic: 'world' }],
-				measurementOptions: {},
-			});
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith('G654');
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'traceroute',
+					target: 'google.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'world' }],
+					measurementOptions: {},
+				},
+				'tok3n',
+			);
 
 			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
 
@@ -401,12 +482,273 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedReply);
 		});
 
+		it('should handle the command - auth login', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			interactionMock.options = {
+				getSubcommand: () => 'login',
+				getSubcommandGroup: () => 'auth',
+			} as any;
+
+			interactionMock.member = {
+				permissions: {
+					has: vi.fn().mockReturnValue(true),
+				},
+			} as any;
+
+			vi.spyOn(oauthClientMock, 'Authorize').mockResolvedValue({
+				url: 'https://globalping.io/auth',
+			});
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(oauthClientMock.Authorize).toHaveBeenCalledWith('G654', {
+				userId: '123',
+				channelId: 'C123',
+			});
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith({
+				embeds: [
+					{
+						description: `Please [click here](https://globalping.io/auth) to authenticate.
+
+**Note:** The login is set for the server. Once logged in, account credits are shared between all users in the server.`,
+					},
+				],
+			});
+		});
+
+		it('should handle the command - auth login - cannot use the command', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			interactionMock.options = {
+				getSubcommand: () => 'login',
+				getSubcommandGroup: () => 'auth',
+			} as any;
+
+			interactionMock.member = {
+				permissions: {
+					has: vi.fn().mockReturnValue(false),
+				},
+			} as any;
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(oauthClientMock.Authorize).toHaveBeenCalledTimes(0);
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith({
+				content: 'Only administrators can use this command.',
+			});
+		});
+
+		it('should handle the command - auth logout', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			interactionMock.options = {
+				getSubcommand: () => 'logout',
+				getSubcommandGroup: () => 'auth',
+			} as any;
+
+			interactionMock.member = {
+				permissions: {
+					has: vi.fn().mockReturnValue(true),
+				},
+			} as any;
+
+			vi.spyOn(oauthClientMock, 'Logout').mockResolvedValue(null);
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith({
+				content: 'You are now logged out.',
+			});
+		});
+
+		it('should handle the command - auth status', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			interactionMock.options = {
+				getSubcommand: () => 'status',
+				getSubcommandGroup: () => 'auth',
+			} as any;
+
+			interactionMock.member = {
+				permissions: {
+					has: vi.fn().mockReturnValue(true),
+				},
+			} as any;
+
+			vi.spyOn(oauthClientMock, 'Introspect').mockResolvedValue([
+				{
+					active: true,
+					username: 'john',
+				},
+				null,
+			]);
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(oauthClientMock.Introspect).toHaveBeenCalledWith('G654');
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith({
+				content: 'Logged in as john.',
+			});
+		});
+
+		it('should handle the command - auth status anonymous', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			interactionMock.options = {
+				getSubcommand: () => 'status',
+				getSubcommandGroup: () => 'auth',
+			} as any;
+
+			interactionMock.member = {
+				permissions: {
+					has: vi.fn().mockReturnValue(true),
+				},
+			} as any;
+
+			vi.spyOn(oauthClientMock, 'Introspect').mockResolvedValue([
+				{
+					active: true,
+				},
+				null,
+			]);
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(oauthClientMock.Introspect).toHaveBeenCalledWith('G654');
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith({
+				content: 'Not logged in.',
+			});
+		});
+
+		it('should handle the command - limits', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			interactionMock.options = {
+				getSubcommand: () => 'limits',
+				getSubcommandGroup: () => undefined,
+			} as any;
+
+			vi.spyOn(oauthClientMock, 'Introspect').mockResolvedValue([
+				{
+					active: true,
+					username: 'john',
+				},
+				null,
+			]);
+
+			vi.spyOn(oauthClientMock, 'Limits').mockResolvedValue([
+				{
+					rateLimit: {
+						measurements: {
+							create: {
+								type: CreateLimitType.User,
+								limit: 500,
+								remaining: 350,
+								reset: 600,
+							},
+						},
+					},
+					credits: {
+						remaining: 1000,
+					},
+				},
+				null,
+			]);
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(oauthClientMock.Introspect).toHaveBeenCalledWith('G654');
+
+			const expectedText = `Authentication: token (john)
+
+Creating measurements:
+ - 500 tests per hour
+ - 150 consumed, 350 remaining
+ - resets in 10 minutes
+
+Credits:
+ - 1000 credits remaining (may be used to create measurements above the hourly limits)
+`;
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith({
+				content: expectedText,
+			});
+		});
+
+		it('should handle the command - limits IP', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			interactionMock.options = {
+				getSubcommand: () => 'limits',
+				getSubcommandGroup: () => undefined,
+			} as any;
+
+			vi.spyOn(oauthClientMock, 'Introspect').mockResolvedValue([
+				{
+					active: true,
+					username: 'john',
+				},
+				null,
+			]);
+
+			vi.spyOn(oauthClientMock, 'Limits').mockResolvedValue([
+				{
+					rateLimit: {
+						measurements: {
+							create: {
+								type: CreateLimitType.IP,
+								limit: 500,
+								remaining: 500,
+								reset: 0,
+							},
+						},
+					},
+				},
+				null,
+			]);
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(oauthClientMock.Introspect).toHaveBeenCalledWith('G654');
+
+			const expectedText = `Authentication: workspace
+
+Creating measurements:
+ - 500 tests per hour
+ - 0 consumed, 500 remaining
+`;
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith({
+				content: expectedText,
+			});
+		});
+
 		it('should handle the command - /globalping help', async () => {
 			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
 
 			const options: Record<string, string | number | boolean> = {};
 			interactionMock.options = {
 				getSubcommand: () => 'help',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
@@ -414,13 +756,14 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			await bot.HandleInteraction(interactionMock);
 
-			expect(interactionMock.deferReply).toHaveBeenCalled();
-
 			expect(postMeasurementMock).toHaveBeenCalledTimes(0);
 
 			expect(getMeasurementMock).toHaveBeenCalledTimes(0);
 
-			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedHelpTexts.general);
+			expect(interactionMock.reply).toHaveBeenCalledWith({
+				content: expectedHelpTexts.general,
+				flags: MessageFlags.Ephemeral,
+			});
 
 			if (expectedHelpTexts.general.length > discordMessageLimit) {
 				throw new Error(`The message must have at most ${discordMessageLimit} characters. Got ${expectedHelpTexts.general.length}`);
@@ -435,6 +778,7 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'help',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
@@ -442,13 +786,14 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			await bot.HandleInteraction(interactionMock);
 
-			expect(interactionMock.deferReply).toHaveBeenCalled();
-
 			expect(postMeasurementMock).toHaveBeenCalledTimes(0);
 
 			expect(getMeasurementMock).toHaveBeenCalledTimes(0);
 
-			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedHelpTexts.ping);
+			expect(interactionMock.reply).toHaveBeenCalledWith({
+				content: expectedHelpTexts.ping,
+				flags: MessageFlags.Ephemeral,
+			});
 
 			if (expectedHelpTexts.ping.length > discordMessageLimit) {
 				throw new Error(`The message must have at most ${discordMessageLimit} characters. Got ${expectedHelpTexts.ping.length}`);
@@ -463,6 +808,7 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'help',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
@@ -470,13 +816,14 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			await bot.HandleInteraction(interactionMock);
 
-			expect(interactionMock.deferReply).toHaveBeenCalled();
-
 			expect(postMeasurementMock).toHaveBeenCalledTimes(0);
 
 			expect(getMeasurementMock).toHaveBeenCalledTimes(0);
 
-			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedHelpTexts.dns);
+			expect(interactionMock.reply).toHaveBeenCalledWith({
+				content: expectedHelpTexts.dns,
+				flags: MessageFlags.Ephemeral,
+			});
 
 			if (expectedHelpTexts.dns.length > discordMessageLimit) {
 				throw new Error(`The message must have at most ${discordMessageLimit} characters. Got ${expectedHelpTexts.dns.length}`);
@@ -491,6 +838,7 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'help',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
@@ -498,13 +846,14 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			await bot.HandleInteraction(interactionMock);
 
-			expect(interactionMock.deferReply).toHaveBeenCalled();
-
 			expect(postMeasurementMock).toHaveBeenCalledTimes(0);
 
 			expect(getMeasurementMock).toHaveBeenCalledTimes(0);
 
-			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedHelpTexts.http);
+			expect(interactionMock.reply).toHaveBeenCalledWith({
+				content: expectedHelpTexts.http,
+				flags: MessageFlags.Ephemeral,
+			});
 
 			if (expectedHelpTexts.http.length > discordMessageLimit) {
 				throw new Error(`The message must have at most ${discordMessageLimit} characters. Got ${expectedHelpTexts.http.length}`);
@@ -519,6 +868,7 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'help',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
@@ -526,13 +876,14 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			await bot.HandleInteraction(interactionMock);
 
-			expect(interactionMock.deferReply).toHaveBeenCalled();
-
 			expect(postMeasurementMock).toHaveBeenCalledTimes(0);
 
 			expect(getMeasurementMock).toHaveBeenCalledTimes(0);
 
-			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedHelpTexts.mtr);
+			expect(interactionMock.reply).toHaveBeenCalledWith({
+				content: expectedHelpTexts.mtr,
+				flags: MessageFlags.Ephemeral,
+			});
 
 			if (expectedHelpTexts.mtr.length > discordMessageLimit) {
 				throw new Error(`The message must have at most ${discordMessageLimit} characters. Got ${expectedHelpTexts.mtr.length}`);
@@ -547,6 +898,7 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 			};
 			interactionMock.options = {
 				getSubcommand: () => 'help',
+				getSubcommandGroup: () => undefined,
 				getString: (key: string) => options[key] as string,
 				getNumber: (key: string) => options[key] as number,
 				getBoolean: (key: string) => options[key] as boolean,
@@ -554,17 +906,151 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 
 			await bot.HandleInteraction(interactionMock);
 
-			expect(interactionMock.deferReply).toHaveBeenCalled();
-
 			expect(postMeasurementMock).toHaveBeenCalledTimes(0);
 
 			expect(getMeasurementMock).toHaveBeenCalledTimes(0);
 
-			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedHelpTexts.traceroute);
+			expect(interactionMock.reply).toHaveBeenCalledWith({
+				content: expectedHelpTexts.traceroute,
+				flags: MessageFlags.Ephemeral,
+			});
 
 			if (expectedHelpTexts.traceroute.length > discordMessageLimit) {
 				throw new Error(`The message must have at most ${discordMessageLimit} characters. Got ${expectedHelpTexts.traceroute.length}`);
 			}
+		});
+	});
+
+	describe('OnAuthCallback', () => {
+		it('should exchange a new token, revoke the old token, and post a success message in slack', async () => {
+			const code = 'code';
+			const userId = 'U123';
+			const channelId = 'C123';
+			const id = 'U' + userId;
+
+			const now = new Date();
+
+			const token: AuthToken = {
+				access_token: 'tok3n',
+				refresh_token: 'refresh_tok3n',
+				expires_in: 3600,
+				token_type: 'Bearer',
+				expiry: now.getTime() / 1000 - 3600,
+			};
+
+			const authorizeSession: AuthorizeSession = {
+				callbackVerifier: 'callback',
+				exchangeVerifier: 'verifier',
+				userId,
+				channelId,
+			};
+
+			vi.spyOn(dbClientMock, 'getDataForAuthorization').mockResolvedValue({
+				token,
+				session: authorizeSession,
+			});
+
+			const req = {
+				url: `/oauth/callback?code=${code}&state=${authorizeSession.callbackVerifier}-${id}`,
+			} as IncomingMessage;
+			const res = {
+				writeHead: vi.fn(),
+				end: vi.fn(),
+			} as any;
+
+			const sendMock = vi.fn();
+			vi.spyOn(discordClientMock.channels.cache, 'get').mockReturnValue({
+				send: sendMock,
+			} as any);
+
+			await bot.OnAuthCallback(req, res);
+
+			expect(dbClientMock.getDataForAuthorization).toHaveBeenCalledWith(id);
+
+			expect(dbClientMock.updateAuthorizeSession).toHaveBeenCalledWith(
+				id,
+				null,
+			);
+
+			expect(oauthClientMock.Exchange).toHaveBeenCalledWith(
+				code,
+				authorizeSession.exchangeVerifier,
+				id,
+			);
+
+			expect(oauthClientMock.RevokeToken).toHaveBeenCalledWith(token.refresh_token);
+
+			expect(discordClientMock.channels.cache.get).toHaveBeenCalledWith(channelId);
+
+			expect(sendMock).toHaveBeenCalledWith('Success! You are now authenticated.');
+
+			expect(res.writeHead).toHaveBeenCalledWith(302, {
+				Location: `${configMock.dashboardUrl}/authorize/success`,
+			});
+
+			expect(res.end).toHaveBeenCalled();
+		});
+
+		it('should redirect to the error page - callback verifier does not match', async () => {
+			const code = 'code';
+			const userId = 'U123';
+			const channelId = 'C123';
+			const id = 'U' + userId;
+
+			const now = new Date();
+
+			const token: AuthToken = {
+				access_token: 'tok3n',
+				refresh_token: 'refresh_tok3n',
+				expires_in: 3600,
+				token_type: 'Bearer',
+				expiry: now.getTime() / 1000 - 3600,
+			};
+
+			const authorizeSession: AuthorizeSession = {
+				callbackVerifier: 'callback',
+				exchangeVerifier: 'verifier',
+				userId,
+				channelId,
+			};
+
+			vi.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+			vi.spyOn(dbClientMock, 'getDataForAuthorization').mockResolvedValue({
+				token,
+				session: {
+					...authorizeSession,
+					callbackVerifier: 'wrong',
+				},
+			});
+
+			const fetchSpy = vi.spyOn(global, 'fetch');
+
+			const req = {
+				url: `/oauth/callback?code=${code}&state=${authorizeSession.callbackVerifier}-${id}`,
+			} as IncomingMessage;
+			const res = {
+				writeHead: vi.fn(),
+				end: vi.fn(),
+			} as any;
+
+			await bot.OnAuthCallback(req, res);
+
+			expect(dbClientMock.getDataForAuthorization).toHaveBeenCalledWith(id);
+
+			expect(dbClientMock.updateAuthorizeSession).toHaveBeenCalledTimes(0);
+
+			expect(dbClientMock.updateToken).toHaveBeenCalledTimes(0);
+
+			expect(fetchSpy).toHaveBeenCalledTimes(0);
+
+			// expect(slackClientMock.chat.postEphemeral).toHaveBeenCalledTimes(0);
+
+			expect(res.writeHead).toHaveBeenCalledWith(302, {
+				Location: `${configMock.dashboardUrl}/authorize/error`,
+			});
+
+			expect(res.end).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/discord/tests/utils.ts
+++ b/packages/discord/tests/utils.ts
@@ -1,8 +1,9 @@
 import { vi } from 'vitest';
 
 import probeData from '@globalping/bot-utils/dist/tests/mocks/probedata.json' assert { type: 'json' };
-import { Logger, Measurement } from '@globalping/bot-utils';
-import { ChatInputCommandInteraction } from 'discord.js';
+import { Logger, Measurement, OAuthClient } from '@globalping/bot-utils';
+import { ChatInputCommandInteraction, Client } from 'discord.js';
+import { DBClient } from '../src/db.js';
 
 export const mockLogger = (): Logger => ({
 	info: vi.fn(),
@@ -14,6 +15,7 @@ export const mockDiscordInteraction = (): ChatInputCommandInteraction => ({
 	isChatInputCommand: vi.fn(),
 	deferReply: vi.fn(),
 	editReply: vi.fn(),
+	reply: vi.fn(),
 	commandName: 'globalping',
 	options: {
 		getSubcommand: vi.fn(),
@@ -21,13 +23,47 @@ export const mockDiscordInteraction = (): ChatInputCommandInteraction => ({
 		getNumber: vi.fn(),
 		getBoolean: vi.fn(),
 	},
+	inGuild: () => true,
+	guildId: '654',
+	channelId: 'C123',
 	user: {
 		id: '123',
 	},
 }) as any;
 
+export const mockDiscordClient = (): Client => ({
+	users: {
+		cache: {
+			get: vi.fn(),
+		},
+	},
+	channels: {
+		cache: {
+			get: vi.fn(),
+		},
+	},
+}) as any;
+
+export const mockDBClient = (): DBClient => ({
+	getToken: vi.fn(),
+	updateToken: vi.fn(),
+	updateAuthorizeSession: vi.fn(),
+	getDataForAuthorization: vi.fn(),
+}) as any;
+
 export const mockPostMeasurement = () => vi.fn();
 export const mockGetMeasurement = () => vi.fn();
+
+export const mockAuthClient = (): OAuthClient => ({
+	Authorize: vi.fn(),
+	Logout: vi.fn(),
+	Introspect: vi.fn(),
+	Limits: vi.fn(),
+	GetToken: vi.fn(),
+	TryToRefreshToken: vi.fn(),
+	Exchange: vi.fn(),
+	RevokeToken: vi.fn(),
+}) as any;
 
 export const getDefaultDnsResponse = (): Measurement => {
 	return probeData.dns1 as any;

--- a/packages/main/migrations/202503131200_add_discord_users.js
+++ b/packages/main/migrations/202503131200_add_discord_users.js
@@ -1,0 +1,21 @@
+import { Tables } from "@globalping/bot-utils";
+
+export const up = async (knex) => {
+	if (!(await knex.schema.hasTable(Tables.DiscordUsers))) {
+		console.log("Creating discord_users table");
+
+		await knex.schema.createTable(Tables.DiscordUsers, (table) => {
+			table.string("id").primary();
+			table.json("token");
+			table.json("authorize_session");
+			table.json("anonymous_token");
+		});
+	}
+};
+
+export const down = async (knex) => {
+	if (await knex.schema.hasTable(Tables.DiscordUsers)) {
+		console.log("Dropping discord_users table");
+		await knex.schema.dropTable(Tables.DiscordUsers);
+	}
+};

--- a/packages/main/src/config.ts
+++ b/packages/main/src/config.ts
@@ -21,6 +21,9 @@ export const config = {
 	authUrl: process.env.AUTH_URL as string,
 	authClientId: process.env.AUTH_CLIENT_ID as string,
 	authClientSecret: process.env.AUTH_CLIENT_SECRET as string,
+	authDiscordClientId: process.env.AUTH_DISCORD_CLIENT_ID as string,
+	authDiscordClientSecret: process.env.AUTH_DISCORD_CLIENT_SECRET as string,
+	authCallbackPath: '',
 
 	slackSigningSecret: process.env.SLACK_SIGNING_SECRET as string,
 	slackClientId: process.env.SLACK_CLIENT_ID as string,

--- a/packages/main/src/discord/deploy-commands.ts
+++ b/packages/main/src/discord/deploy-commands.ts
@@ -1,18 +1,19 @@
 import { scopedLogger } from '@globalping/bot-utils';
-import { deployCommands, Config } from 'discord-bot';
+import { deployCommands, DeployCommandsConfig } from 'discord-bot';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
 
 (async () => {
 	const logger = scopedLogger('main');
-	const config: Config = {
+	const config: DeployCommandsConfig = {
 		discordToken: process.env.DISCORD_TOKEN as string,
 		discordAppId: process.env.DISCORD_APP_ID as string,
 	};
 
 	if (!config.discordToken || !config.discordAppId) {
 		logger.error('DISCORD_TOKEN and DISCORD_APP_ID environment variables must be set');
+
 		process.exit(1);
 	}
 

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -8,14 +8,13 @@ import { config } from './config.js';
 
 import { faviconHandler, homeHandler, robotsHandler } from './handlers.js';
 
-
-const migrationsPath = path.join(path.dirname(fileURLToPath(import.meta.url).replace('/dist/', '/')), '../migrations');
+const migrationsPath = path.join(
+	path.dirname(fileURLToPath(import.meta.url).replace('/dist/', '/')),
+	'../migrations',
+);
 const knex = initKnexClient(config, migrationsPath);
 
 const logger = scopedLogger('main');
-
-const githubBot = initGithubBot(config, scopedLogger('github'));
-const discordBot = initDiscordBot(scopedLogger('discord'));
 
 const routes: CustomRoute[] = [
 	{
@@ -71,7 +70,52 @@ const routes: CustomRoute[] = [
 	},
 ];
 
-const app = initApp(config, scopedLogger('slack'), knex, routes);
+const githubBot = initGithubBot(
+	{
+		globalpingToken: config.globalpingToken,
+		githubPersonalAccessToken: config.githubPersonalAccessToken,
+		githubBotApiKey: config.githubBotApiKey,
+		githubBotHandle: config.githubBotHandle,
+	},
+	scopedLogger('github'),
+);
+const discordBot = initDiscordBot(
+	{
+		serverHost: config.serverHost,
+		apiUrl: config.apiUrl,
+		dashboardUrl: config.dashboardUrl,
+		authUrl: config.authUrl,
+		authClientId: config.authDiscordClientId,
+		authClientSecret: config.authDiscordClientSecret,
+		authCallbackPath: '/discord/oauth/callback',
+	},
+	scopedLogger('discord'),
+	knex,
+	routes,
+);
+const app = initApp(
+	{
+		env: config.env,
+
+		serverHost: config.serverHost,
+		apiUrl: config.apiUrl,
+		dashboardUrl: config.dashboardUrl,
+		authUrl: config.authUrl,
+		authClientId: config.authClientId,
+		authClientSecret: config.authClientSecret,
+		authCallbackPath: '/slack/oauth/callback',
+
+		slackSigningSecret: config.slackSigningSecret,
+		slackClientId: config.slackClientId,
+		slackClientSecret: config.slackClientSecret,
+		slackStateSecret: config.slackStateSecret,
+		slackSocketMode: config.slackSocketMode,
+		slackAppToken: config.slackAppToken,
+	},
+	scopedLogger('slack'),
+	knex,
+	routes,
+);
 
 // Start the app
 (async () => {

--- a/packages/slack/src/bot.ts
+++ b/packages/slack/src/bot.ts
@@ -1,5 +1,6 @@
 import {
 	AllMiddlewareArgs,
+	Installation,
 	InstallationQuery,
 	SlackCommandMiddlewareArgs,
 	SlackEventMiddlewareArgs,
@@ -23,10 +24,14 @@ import {
 	Measurement,
 	MeasurementCreateResponse,
 	Logger,
-	pluralize,
-	formatSeconds,
 	generateHelp,
 	HelpTexts,
+	AuthToken,
+	AuthorizeError,
+	AuthorizeErrorType,
+	OAuthClient,
+	getTooManyRequestsError,
+	getLimitsOutput,
 } from '@globalping/bot-utils';
 import type {
 	Block,
@@ -35,15 +40,10 @@ import type {
 	RichTextBlockElement,
 	WebClient,
 } from '@slack/web-api';
-import {
-	AuthorizeErrorType,
-	CreateLimitType,
-	IntrospectionResponse,
-	LimitsResponse,
-	OAuthClient,
-} from './auth.js';
 import { formatMeasurementResponse } from './response.js';
-import { DBClient } from './db.js';
+import { AuthorizeSession, DBClient } from './db.js';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Config, SlackClient } from './types.js';
 
 const welcomeMap: Record<string, boolean> = {};
 const welcomeMapTimeout = 10_000;
@@ -74,9 +74,11 @@ interface ChannelPayload {
 
 export class Bot {
 	private help: HelpTexts;
+	private slackClient?: SlackClient;
 
 	constructor (
 		private logger: Logger,
+		private config: Config,
 		private dbClient: DBClient,
 		private oauth: OAuthClient,
 		private postMeasurement: (
@@ -86,6 +88,10 @@ export class Bot {
 		private getMeasurement: (id: string) => Promise<Measurement>,
 	) {
 		this.help = generateHelp('*', '/globalping');
+	}
+
+	SetSlackClient (client: SlackClient) {
+		this.slackClient = client;
 	}
 
 	async HandleHomeOpened ({
@@ -121,7 +127,10 @@ export class Bot {
 		const historyLength = history?.messages?.length;
 
 		if (historyLength !== undefined && historyLength > 0) {
-			this.logger.info('Not sending welcome message, history present.', logData);
+			this.logger.info(
+				'Not sending welcome message, history present.',
+				logData,
+			);
 
 			return;
 		}
@@ -183,11 +192,7 @@ export class Bot {
 			await ack();
 		} catch (error) {
 			const err = error as Error;
-			this.logger.info(
-				'HandleCommand: ack failed',
-				err,
-				logData,
-			);
+			this.logger.info('HandleCommand: ack failed', err, logData);
 
 			await respond({
 				text: `Unable to acknowledge the request.\n${formatAPIError(err.message)}`,
@@ -229,10 +234,10 @@ export class Bot {
 						conversation.channel?.id
 						&& channel_id !== conversation.channel.id
 					) {
-						this.logger.error(
-							'HandleCommand: response - dm',
-							{ errorMsg: 'request in dm', ...logData },
-						);
+						this.logger.error('HandleCommand: response - dm', {
+							errorMsg: 'request in dm',
+							...logData,
+						});
 
 						await respond({
 							text:
@@ -248,10 +253,10 @@ export class Bot {
 				}
 
 				if (channel_name.startsWith('mpdm-')) {
-					this.logger.error(
-						'HandleCommand: response - mpdm',
-						{ errorMsg: 'request in mpdm', ...logData },
-					);
+					this.logger.error('HandleCommand: response - mpdm', {
+						errorMsg: 'request in mpdm',
+						...logData,
+					});
 
 					await respond({
 						text:
@@ -264,10 +269,10 @@ export class Bot {
 				}
 
 				// If not DM, try checking the properties of the channel
-				this.logger.error(
-					'HandleCommand: channel invite needed',
-					{ errorMsg: 'asked for invite to channel', ...logData },
-				);
+				this.logger.error('HandleCommand: channel invite needed', {
+					errorMsg: 'asked for invite to channel',
+					...logData,
+				});
 
 				await respond('Please invite me to this channel to use this command. Run `/invite @Globalping` to invite me.');
 
@@ -294,7 +299,10 @@ export class Bot {
 			await this.processCommand(client, channelPayload, commandText);
 		} catch (error) {
 			const errorMsg = getAPIErrorMessage(error);
-			this.logger.error('HandleCommand: failed', error, { errorMsg, ...logData });
+			this.logger.error('HandleCommand: failed', error, {
+				errorMsg,
+				...logData,
+			});
 
 			await respond({
 				text: `Failed to process command \`${text}\`.\n${formatAPIError(errorMsg)}`,
@@ -345,6 +353,170 @@ export class Bot {
 			getInstallationId(context),
 			client,
 		);
+	}
+
+	async OnAuthCallback (req: IncomingMessage, res: ServerResponse) {
+		if (!this.slackClient) {
+			this.logger.error('Slack client not set');
+			res.writeHead(500);
+			res.end();
+			return;
+		}
+
+		const url = new URL(req.url || '', this.config.serverHost);
+		const callbackError = url.searchParams.get('error');
+		const errorDescription = url.searchParams.get('error_description');
+		const code = url.searchParams.get('code');
+		const state = url.searchParams.get('state');
+
+		if (!state) {
+			this.logger.error('/oauth/callback missing state', { callbackError });
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		const separatorIndex = state.indexOf('-');
+		const callbackVerifier = state.substring(0, separatorIndex);
+		const installationId = state.substring(separatorIndex + 1);
+
+		let oldToken: AuthToken | null;
+		let session: AuthorizeSession | null;
+		let installation: Installation | null;
+
+		try {
+			const installationRes
+				= await this.dbClient.getInstallationForAuthorization(installationId);
+			oldToken = installationRes.token;
+			session = installationRes.session;
+			installation = installationRes.installation;
+		} catch {
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		if (!session) {
+			this.logger.error('/oauth/callback missing session', { installationId });
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		if (callbackVerifier !== session.callbackVerifier) {
+			this.logger.error('/oauth/callback invalid verifier', {
+				installationId,
+			});
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		try {
+			// Delete session
+			await this.dbClient.updateAuthorizeSession(installationId, null);
+		} catch (error) {
+			this.logger.error('/oauth/callback failed to delete session', error);
+		}
+
+		if (callbackError || !code) {
+			try {
+				await this.slackClient.chat.postEphemeral({
+					token: installation?.bot?.token,
+					text: `Authentication failed: ${callbackError}: ${errorDescription}`,
+					user: session.userId,
+					channel: session.channelId,
+					thread_ts: session.threadTs,
+				});
+			} catch (error) {
+				this.logger.error('/oauth/callback failed to post ephemeral', error);
+			}
+
+			this.logger.error('/oauth/callback failed', {
+				error: callbackError,
+				errorDescription,
+				code,
+				installationId,
+			});
+
+			res.writeHead(302, {
+				Location: `${this.config.dashboardUrl}/authorize/error`,
+			});
+
+			res.end();
+			return;
+		}
+
+		let exchangeError: AuthorizeError | null;
+
+		try {
+			exchangeError = await this.oauth.Exchange(
+				code,
+				session.exchangeVerifier,
+				installationId,
+			);
+
+			// Revoke old token if exists
+			if (!exchangeError && oldToken && oldToken.refresh_token) {
+				try {
+					await this.oauth.RevokeToken(oldToken.refresh_token);
+				} catch (error) {
+					this.logger.error('/oauth/callback failed to revoke token', {
+						installationId,
+						error,
+					});
+				}
+			}
+		} catch {
+			exchangeError = {
+				error: AuthorizeErrorType.InternalError,
+				error_description: 'Failed to exchange code',
+			};
+		}
+
+		let message = '';
+
+		if (exchangeError) {
+			this.logger.error('/oauth/callback failed', exchangeError);
+			message = `Authentication failed: ${exchangeError.error}: ${exchangeError.error_description}`;
+		} else {
+			message = 'Success! You are now authenticated.';
+		}
+
+		try {
+			await this.slackClient.chat.postEphemeral({
+				token: installation?.bot?.token,
+				text: message,
+				user: session.userId,
+				channel: session.channelId,
+				thread_ts: session.threadTs,
+			});
+		} catch (error) {
+			this.logger.error('/oauth/callback failed to post ephemeral', error);
+		}
+
+		res.writeHead(302, {
+			Location:
+				this.config.dashboardUrl
+				+ (exchangeError ? '/authorize/error' : '/authorize/success'),
+		});
+
+		res.end();
 	}
 
 	private async processMention (
@@ -467,33 +639,7 @@ export class Bot {
 
 				// Too many requests
 				if (statusCode === 429) {
-					const rateLimitRemaining = parseInt(headers['X-RateLimit-Remaining'] as string);
-					const rateLimitReset = parseInt(headers['X-RateLimit-Reset'] as string);
-					const creditsRemaining = parseInt(headers['X-Credits-Remaining'] as string);
-					const requestCost = parseInt(headers['X-Request-Cost'] as string);
-					const remaining = rateLimitRemaining + creditsRemaining;
-
-					if (token && !token.isAnonymous) {
-						if (remaining > 0) {
-							throw getMoreCreditsRequiredAuthError(
-								requestCost,
-								remaining,
-								rateLimitReset,
-							);
-						}
-
-						throw getNoCreditsAuthError(rateLimitReset);
-					} else {
-						if (remaining > 0) {
-							throw getMoreCreditsRequiredNoAuthError(
-								remaining,
-								requestCost,
-								rateLimitReset,
-							);
-						}
-
-						throw getNoCreditsNoAuthError(rateLimitReset);
-					}
+					throw getTooManyRequestsError(headers, token);
 				}
 			}
 
@@ -530,7 +676,11 @@ export class Bot {
 			return;
 		}
 
-		const res = await this.oauth.Authorize(payload);
+		const res = await this.oauth.Authorize(payload.installationId, {
+			channelId: payload.channel_id,
+			userId: payload.user_id,
+			threadTs: payload.thread_ts,
+		});
 		await client.chat.postEphemeral({
 			blocks: [
 				{
@@ -706,76 +856,4 @@ function traverseBlocks (
 			traverseBlocks(block.elements, callback);
 		}
 	}
-}
-
-export function getLimitsOutput (
-	limits: LimitsResponse,
-	introspection: IntrospectionResponse,
-) {
-	let text = '';
-
-	if (limits.rateLimit.measurements.create.type === CreateLimitType.User) {
-		text = `Authentication: token (${introspection?.username || ''})\n\n`;
-	} else {
-		text = 'Authentication: workspace\n\n';
-	}
-
-	const createLimit = pluralize(
-		limits.rateLimit.measurements.create.limit,
-		'test',
-	);
-	const createConsumed
-		= limits.rateLimit.measurements.create.limit
-		- limits.rateLimit.measurements.create.remaining;
-	const createRemaining = limits.rateLimit.measurements.create.remaining;
-	text += `Creating measurements:
- - ${createLimit} per hour
- - ${createConsumed} consumed, ${createRemaining} remaining
-`;
-
-	if (limits.rateLimit.measurements.create.reset) {
-		text += ` - resets in ${formatSeconds(limits.rateLimit.measurements.create.reset)}\n`;
-	}
-
-	if (limits.rateLimit.measurements.create.type === CreateLimitType.User) {
-		text += `
-Credits:
- - ${pluralize(
-		limits.credits?.remaining || 0,
-		'credit',
-	)} remaining (may be used to create measurements above the hourly limits)
-`;
-	}
-
-	return text;
-}
-
-export function getMoreCreditsRequiredAuthError (
-	requestCost: number,
-	remaining: number,
-	rateLimitReset: number,
-): Error {
-	return new Error(`You only have ${pluralize(
-		remaining,
-		'credit',
-	)} remaining, and ${requestCost} were required. Try requesting fewer probes or wait ${formatSeconds(rateLimitReset)} for the rate limit to reset. You can get higher limits by sponsoring us or hosting probes.`);
-}
-
-export function getNoCreditsAuthError (rateLimitReset: number): Error {
-	return new Error(`You have run out of credits for this session. You can wait ${formatSeconds(rateLimitReset)} for the rate limit to reset or get higher limits by sponsoring us or hosting probes.`);
-}
-
-export function getMoreCreditsRequiredNoAuthError (
-	requestCost: number,
-	remaining: number,
-	rateLimitReset: number,
-): Error {
-	return new Error(`You only have ${pluralize(
-		remaining,
-		'credit',
-	)} remaining, and ${requestCost} were required. Try requesting fewer probes or wait ${formatSeconds(rateLimitReset)} for the rate limit to reset. You can get higher limits by creating an account. Sign up at https://globalping.io`);
-}
-
-export function getNoCreditsNoAuthError (rateLimitReset: number): Error {
-	return new Error(`You have run out of credits for this session. You can wait ${formatSeconds(rateLimitReset)} for the rate limit to reset or get higher limits by creating an account. Sign up at https://globalping.io`);
 }

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -6,21 +6,15 @@ export type { CustomRoute } from '@slack/bolt';
 
 export interface Config {
 	env: string;
-	logLevel: string;
 
 	serverHost: string;
-
-	dbHost: string;
-	dbPort: number;
-	dbUser: string;
-	dbPassword: string;
-	dbDatabase: string;
 
 	apiUrl: string;
 	dashboardUrl: string;
 	authUrl: string;
 	authClientId: string;
 	authClientSecret: string;
+	authCallbackPath: string;
 
 	slackSigningSecret: string;
 	slackClientId: string;

--- a/packages/slack/tests/utils.ts
+++ b/packages/slack/tests/utils.ts
@@ -1,9 +1,8 @@
 import { vi } from 'vitest';
 
 import { SlackClient } from '../src/types.js';
-import { OAuthClient } from '../src/auth.js';
 import probeData from '@globalping/bot-utils/tests/mocks/probedata.json' assert { type: 'json' };
-import { Logger, Measurement } from '@globalping/bot-utils';
+import { Logger, Measurement, OAuthClient } from '@globalping/bot-utils';
 import { DBClient } from '../src/db.js';
 
 export const mockLogger = (): Logger => ({
@@ -42,6 +41,8 @@ export const mockAuthClient = (): OAuthClient => ({
 	Limits: vi.fn(),
 	GetToken: vi.fn(),
 	TryToRefreshToken: vi.fn(),
+	Exchange: vi.fn(),
+	RevokeToken: vi.fn(),
 }) as any;
 
 export const getDefaultDnsResponse = (): Measurement => {


### PR DESCRIPTION
Added commands: `limits`, `auth login`, `auth status` and `auth logout`.
The auth commands can be run within a server only by users with `Administrator` privileges.

The following must be added to `env`:
`AUTH_DISCORD_CLIENT_ID`
`AUTH_DISCORD_CLIENT_SECRET`

`pnpm discord:deploy-commands` must be run to deploy the commands.

Closes #76 



