### PR TITLE
feat: add support for TCP ping

### DIFF
--- a/packages/bot-utils/src/flags.ts
+++ b/packages/bot-utils/src/flags.ts
@@ -19,6 +19,8 @@ const ALLOWED_BASE_FLAGS = [ 'target', 'from', 'limit', 'share' ] as const;
 const ALLOWED_PING_FLAGS = [
 	'packets',
 	'latency',
+	'protocol',
+	'port',
 	...ALLOWED_BASE_FLAGS,
 ] as const;
 

--- a/packages/bot-utils/src/help.ts
+++ b/packages/bot-utils/src/help.ts
@@ -364,6 +364,21 @@ export const pingHelpTexts = {
 			description:
 				'Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)',
 		},
+		{
+			name: 'port',
+			type: 'int',
+			shortDescription:
+				'Specify the port to use; only applicable for the TCP protocol (default 80)',
+			description:
+				'Specify the port to use; only applicable for the TCP protocol (default 80)',
+		},
+		{
+			name: 'protocol',
+			type: 'string',
+			shortDescription:
+				'Specifies the protocol to use: ICMP or TCP (default ICMP)',
+			description: 'Specifies the protocol to use: ICMP or TCP (default ICMP)',
+		},
 	],
 };
 export const pingFlagsMap = new Map<string, HelpFlag>(pingHelpTexts.flags.map(flag => [ flag.name, flag ]));
@@ -535,7 +550,11 @@ The Globalping bot allows you to interact with the API in a simple and human-fri
 	],
 };
 
-function generateFlagsText (title: string, flags: HelpFlag[], hideHelp: boolean): string {
+function generateFlagsText (
+	title: string,
+	flags: HelpFlag[],
+	hideHelp: boolean,
+): string {
 	if (hideHelp) {
 		flags = flags.filter(flag => flag.name !== 'help');
 	}

--- a/packages/bot-utils/src/measurements-request.ts
+++ b/packages/bot-utils/src/measurements-request.ts
@@ -5,6 +5,7 @@ import {
 	ALLOWED_HTTP_METHODS,
 	ALLOWED_HTTP_PROTOCOLS,
 	ALLOWED_MTR_PROTOCOLS,
+	ALLOWED_PING_PROTOCOLS,
 	ALLOWED_QUERY_TYPES,
 	ALLOWED_TRACE_PROTOCOLS,
 	isDnsProtocol,
@@ -12,6 +13,7 @@ import {
 	isHttpMethod,
 	isHttpProtocol,
 	isMtrProtocol,
+	isPingProtocol,
 	isTraceProtocol,
 	Location,
 	MeasurementCreate,
@@ -62,6 +64,16 @@ export const buildPostMeasurements = (args: Flags): MeasurementCreate => {
 				locations,
 				measurementOptions: {
 					...packets && { packets },
+					...protocol && {
+						protocol: isPingProtocol(protocol)
+							? protocol
+							: throwArgError(
+								protocol,
+								'protocol',
+								[ ...ALLOWED_PING_PROTOCOLS ].join(', '),
+							),
+					},
+					...port && { port },
 				},
 			};
 		case 'traceroute':

--- a/packages/bot-utils/src/types.ts
+++ b/packages/bot-utils/src/types.ts
@@ -32,6 +32,10 @@ export const ALLOWED_LOCATION_TYPES = [
 export type LocationType = (typeof ALLOWED_LOCATION_TYPES)[number];
 export const isLocationType = (type: string): type is LocationType => ALLOWED_LOCATION_TYPES.includes(type as LocationType);
 
+export const ALLOWED_PING_PROTOCOLS = [ 'ICMP', 'TCP' ] as const;
+export type PingProtocol = (typeof ALLOWED_PING_PROTOCOLS)[number];
+export const isPingProtocol = (type: string): type is PingProtocol => ALLOWED_PING_PROTOCOLS.includes(type as PingProtocol);
+
 // traceroute
 export const ALLOWED_TRACE_PROTOCOLS = [ 'TCP', 'UDP', 'ICMP' ] as const;
 export type TraceProtocol = (typeof ALLOWED_TRACE_PROTOCOLS)[number];

--- a/packages/bot-utils/tests/help.test.ts
+++ b/packages/bot-utils/tests/help.test.ts
@@ -283,8 +283,10 @@ Ping jsdelivr.com from a probe that is from the AWS network and is located in Mo
 
 *Flags*:
 \`\`\`
-  -h, --help           Help for ping
-      --packets int    Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)
+  -h, --help               Help for ping
+      --packets int        Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)
+      --port int           Specify the port to use; only applicable for the TCP protocol (default 80)
+      --protocol string    Specifies the protocol to use: ICMP or TCP (default ICMP)
 \`\`\`
 
 *Global Flags*:
@@ -344,7 +346,14 @@ Traceroute jsdelivr.com from a probe that is located in Paris to port 453
 		});
 
 		it('should return help texts - hide help flag', async () => {
-			const helpTexts = generateHelp('*', '/globalping', undefined, undefined, undefined, true);
+			const helpTexts = generateHelp(
+				'*',
+				'/globalping',
+				undefined,
+				undefined,
+				undefined,
+				true,
+			);
 
 			const expectedHelpTexts = {
 				auth: `Authenticate with the Globalping API for higher measurements limits.
@@ -599,7 +608,9 @@ Ping jsdelivr.com from a probe that is from the AWS network and is located in Mo
 
 *Flags*:
 \`\`\`
---packets int    Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)
+--packets int        Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)
+--port int           Specify the port to use; only applicable for the TCP protocol (default 80)
+--protocol string    Specifies the protocol to use: ICMP or TCP (default ICMP)
 \`\`\`
 
 *Global Flags*:
@@ -659,23 +670,38 @@ Traceroute jsdelivr.com from a probe that is located in Paris to port 453
 
 		it('should check that short descriptions are less than or equal to 100 chars', async () => {
 			for (const cmd of generalHelpTexts.commands) {
-				expect((cmd.shortDescription || '').length <= 100, `${cmd.name}: ${cmd.shortDescription}`).toBe(true);
+				expect(
+					(cmd.shortDescription || '').length <= 100,
+					`${cmd.name}: ${cmd.shortDescription}`,
+				).toBe(true);
 
 				for (const flag of cmd.flags) {
-					expect((flag.shortDescription || '').length <= 100, `${cmd.name}: ${flag.name}: ${flag.shortDescription}`).toBe(true);
+					expect(
+						(flag.shortDescription || '').length <= 100,
+						`${cmd.name}: ${flag.name}: ${flag.shortDescription}`,
+					).toBe(true);
 				}
 			}
 
 			for (const cmd of generalHelpTexts.additionalCommands) {
-				expect((cmd.shortDescription || '').length <= 100, `${cmd.name}: ${cmd.shortDescription}`).toBe(true);
+				expect(
+					(cmd.shortDescription || '').length <= 100,
+					`${cmd.name}: ${cmd.shortDescription}`,
+				).toBe(true);
 
 				for (const flag of cmd.flags) {
-					expect((flag.shortDescription || '').length <= 100, `${cmd.name}: ${flag.name}: ${flag.shortDescription}`).toBe(true);
+					expect(
+						(flag.shortDescription || '').length <= 100,
+						`${cmd.name}: ${flag.name}: ${flag.shortDescription}`,
+					).toBe(true);
 				}
 			}
 
 			for (const flag of generalHelpTexts.flags) {
-				expect((flag.shortDescription || '').length <= 100, `general: ${flag.name}: ${flag.shortDescription}`).toBe(true);
+				expect(
+					(flag.shortDescription || '').length <= 100,
+					`general: ${flag.name}: ${flag.shortDescription}`,
+				).toBe(true);
 			}
 		});
 	});

--- a/packages/bot-utils/tests/measurements-request.test.ts
+++ b/packages/bot-utils/tests/measurements-request.test.ts
@@ -36,8 +36,8 @@ describe('Utils', () => {
 
 			it('should throw if incorrect ping flag', () => {
 				const args
-					= 'ping google.com from New York --limit 2 --packets 3 --protocol icmp';
-				expect(() => buildPostMeasurements(argsToFlags(args))).toThrow('Invalid option "protocol" for "ping"!\nExpected "packets, latency, target, from, limit, share".');
+					= 'ping google.com from New York --limit 2 --packets 3 --flag invalid';
+				expect(() => buildPostMeasurements(argsToFlags(args))).toThrow('Invalid option "flag" for "ping"!\nExpected "packets, latency, protocol, port, target, from, limit, share".');
 			});
 		});
 

--- a/packages/discord/src/deploy-commands.ts
+++ b/packages/discord/src/deploy-commands.ts
@@ -1,5 +1,6 @@
 import { REST } from '@discordjs/rest';
 import {
+	ALLOWED_PING_PROTOCOLS,
 	ALLOWED_DNS_PROTOCOLS,
 	ALLOWED_DNS_TYPES,
 	ALLOWED_HTTP_METHODS,
@@ -66,6 +67,15 @@ export const deployCommands = (config: DeployCommandsConfig) => {
 				.addBooleanOption(option => option
 					.setName((globalFlagsMap.get('latency') as HelpFlag).name)
 					.setDescription((globalFlagsMap.get('latency') as HelpFlag).shortDescription)
+					.setRequired(false))
+				.addStringOption(option => option
+					.setName((pingFlagsMap.get('protocol') as HelpFlag).name)
+					.setDescription((pingFlagsMap.get('protocol') as HelpFlag).shortDescription)
+					.setRequired(false)
+					.addChoices(...choiceMap([ ...ALLOWED_PING_PROTOCOLS ])))
+				.addNumberOption(option => option
+					.setName((pingFlagsMap.get('port') as HelpFlag).name)
+					.setDescription((pingFlagsMap.get('port') as HelpFlag).shortDescription)
 					.setRequired(false)))
 			// Traceroute
 			.addSubcommand(subcommand => subcommand
@@ -85,7 +95,8 @@ export const deployCommands = (config: DeployCommandsConfig) => {
 					.setRequired(false))
 				.addStringOption(option => option
 					.setName((tracerouteFlagsMap.get('protocol') as HelpFlag).name)
-					.setDescription((tracerouteFlagsMap.get('protocol') as HelpFlag).shortDescription)
+					.setDescription((tracerouteFlagsMap.get('protocol') as HelpFlag)
+						.shortDescription)
 					.setRequired(false)
 					.addChoices(...choiceMap([ ...ALLOWED_TRACE_PROTOCOLS ])))
 				.addNumberOption(option => option

--- a/packages/discord/tests/bot.test.ts
+++ b/packages/discord/tests/bot.test.ts
@@ -43,7 +43,14 @@ describe('Bot', () => {
 	const interactionMock = mockDiscordInteraction();
 	const messageMock = mockDiscordMessage();
 
-	const expectedHelpTexts = generateHelp('**', '/globalping', undefined, 4, 1, true);
+	const expectedHelpTexts = generateHelp(
+		'**',
+		'/globalping',
+		undefined,
+		4,
+		1,
+		true,
+	);
 	const configMock = {
 		serverHost: 'http://localhost',
 		dashboardUrl: 'http://dash.localhost',
@@ -109,6 +116,75 @@ describe('Bot', () => {
 
 			const expectedReply = {
 				content: '<@123>, here are the results for `ping google.com`',
+				embeds: [
+					{
+						fields: [
+							{
+								name: '> **Amsterdam, NL, EU, Gigahost AS (AS56655)**\n',
+								value: codeBlock(expectedResponse.results[0].result.rawOutput),
+							},
+						],
+					},
+				],
+			};
+
+			expect(interactionMock.editReply).toHaveBeenCalledWith(expectedReply);
+		});
+
+		it('should handle the command - /globalping ping with protocol', async () => {
+			vi.spyOn(interactionMock, 'isChatInputCommand').mockReturnValue(true);
+
+			const options: Record<string, string | number | boolean> = {
+				target: 'google.com',
+				protocol: 'TCP',
+				port: 81,
+			};
+			interactionMock.options = {
+				getSubcommand: () => 'ping',
+				getSubcommandGroup: () => undefined,
+				getString: (key: string) => options[key] as string,
+				getNumber: (key: string) => options[key] as number,
+				getBoolean: (key: string) => options[key] as boolean,
+			} as any;
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
+
+			postMeasurementMock.mockResolvedValue({
+				id: 'm345ur3m3nt',
+				probesCount: 1,
+			});
+
+			const expectedResponse = getDefaultPingResponse();
+			getMeasurementMock.mockResolvedValue(expectedResponse);
+
+			await bot.HandleInteraction(interactionMock);
+
+			expect(interactionMock.deferReply).toHaveBeenCalled();
+
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith('G654');
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'ping',
+					target: 'google.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'world' }],
+					measurementOptions: {
+						protocol: 'TCP',
+						port: 81,
+					},
+				},
+				'tok3n',
+			);
+
+			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
+
+			const expectedReply = {
+				content:
+					'<@123>, here are the results for `ping google.com --protocol TCP --port 81`',
 				embeds: [
 					{
 						fields: [
@@ -267,7 +343,8 @@ describe('Bot', () => {
 							},
 							{
 								name: '',
-								value: '> **Full results available here: https://globalping.io?measurement=3KrXt3M4b85vHbhk**\n',
+								value:
+									'> **Full results available here: https://globalping.io?measurement=3KrXt3M4b85vHbhk**\n',
 							},
 						],
 					},
@@ -352,7 +429,8 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 							},
 							{
 								name: '',
-								value: '> **Full results available here: https://globalping.io?measurement=3KrXt3M4b85vHbhk**\n',
+								value:
+									'> **Full results available here: https://globalping.io?measurement=3KrXt3M4b85vHbhk**\n',
 							},
 						],
 					},
@@ -423,7 +501,8 @@ ${(expectedResponse.results[0].result as HttpProbeResult).rawHeaders.slice(0, 62
 							},
 							{
 								name: '',
-								value: '> **Full results available here: https://globalping.io?measurement=HgDbh56ZVZKqpBZh**\n',
+								value:
+									'> **Full results available here: https://globalping.io?measurement=HgDbh56ZVZKqpBZh**\n',
 							},
 						],
 					},
@@ -1003,7 +1082,8 @@ Creating measurements:
 
 			vi.spyOn(messageMock.mentions, 'has').mockReturnValue(true);
 
-			messageMock.content = 'text <@111> dns google.com from Berlin --resolver 1.1.1.1';
+			messageMock.content
+				= 'text <@111> dns google.com from Berlin --resolver 1.1.1.1';
 
 			await bot.HandleMessage(messageMock);
 
@@ -1026,7 +1106,8 @@ Creating measurements:
 			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
 
 			const expectedReply = {
-				content: '<@123>, here are the results for `dns google.com from Berlin --resolver 1.1.1.1`',
+				content:
+					'<@123>, here are the results for `dns google.com from Berlin --resolver 1.1.1.1`',
 				embeds: [
 					{
 						fields: [
@@ -1057,7 +1138,8 @@ Creating measurements:
 
 			vi.spyOn(messageMock.mentions, 'has').mockReturnValue(true);
 
-			messageMock.content = '<@111> http jsdelivr.com --host www.jsdelivr.com --protocol https --port 443 --path "/package/npm/test" --query "nav=stats"';
+			messageMock.content
+				= '<@111> http jsdelivr.com --host www.jsdelivr.com --protocol https --port 443 --path "/package/npm/test" --query "nav=stats"';
 
 			await bot.HandleMessage(messageMock);
 
@@ -1091,7 +1173,8 @@ Creating measurements:
 				+ '\n... (truncated)';
 
 			const expectedReply = {
-				content: '<@123>, here are the results for `http jsdelivr.com --host www.jsdelivr.com --protocol https --port 443 --path "/package/npm/test" --query "nav=stats"`',
+				content:
+					'<@123>, here are the results for `http jsdelivr.com --host www.jsdelivr.com --protocol https --port 443 --path "/package/npm/test" --query "nav=stats"`',
 				embeds: [
 					{
 						fields: [
@@ -1101,7 +1184,8 @@ Creating measurements:
 							},
 							{
 								name: '',
-								value: '> **Full results available here: https://globalping.io?measurement=3KrXt3M4b85vHbhk**\n',
+								value:
+									'> **Full results available here: https://globalping.io?measurement=3KrXt3M4b85vHbhk**\n',
 							},
 						],
 					},
@@ -1161,7 +1245,8 @@ Creating measurements:
 							},
 							{
 								name: '',
-								value: '> **Full results available here: https://globalping.io?measurement=HgDbh56ZVZKqpBZh**\n',
+								value:
+									'> **Full results available here: https://globalping.io?measurement=HgDbh56ZVZKqpBZh**\n',
 							},
 						],
 					},
@@ -1225,7 +1310,11 @@ Creating measurements:
 
 		it('should handle the mention - auth login', async () => {
 			vi.spyOn(messageMock.mentions, 'has').mockReturnValue(true);
-			vi.spyOn((messageMock.member as GuildMember).permissions, 'has').mockReturnValue(true);
+
+			vi.spyOn(
+				(messageMock.member as GuildMember).permissions,
+				'has',
+			).mockReturnValue(true);
 
 			messageMock.content = '<@111> auth login';
 
@@ -1238,14 +1327,17 @@ Creating measurements:
 
 		it('should handle the mention - auth logout', async () => {
 			vi.spyOn(messageMock.mentions, 'has').mockReturnValue(true);
-			vi.spyOn((messageMock.member as GuildMember).permissions, 'has').mockReturnValue(true);
+
+			vi.spyOn(
+				(messageMock.member as GuildMember).permissions,
+				'has',
+			).mockReturnValue(true);
 
 			vi.spyOn(oauthClientMock, 'Logout').mockResolvedValue(null);
 
 			messageMock.content = '<@111> auth logout';
 
 			await bot.HandleMessage(messageMock);
-
 
 			expect(messageMock.reply).toHaveBeenCalledWith({
 				content: 'You are now logged out.',
@@ -1254,8 +1346,11 @@ Creating measurements:
 
 		it('should handle the mention - auth status', async () => {
 			vi.spyOn(messageMock.mentions, 'has').mockReturnValue(true);
-			vi.spyOn((messageMock.member as GuildMember).permissions, 'has').mockReturnValue(true);
 
+			vi.spyOn(
+				(messageMock.member as GuildMember).permissions,
+				'has',
+			).mockReturnValue(true);
 
 			vi.spyOn(oauthClientMock, 'Introspect').mockResolvedValue([
 				{
@@ -1271,7 +1366,6 @@ Creating measurements:
 
 			expect(oauthClientMock.Introspect).toHaveBeenCalledWith('G654');
 
-
 			expect(messageMock.reply).toHaveBeenCalledWith({
 				content: 'Logged in as john.',
 			});
@@ -1279,7 +1373,11 @@ Creating measurements:
 
 		it('should handle the mention - limits', async () => {
 			vi.spyOn(messageMock.mentions, 'has').mockReturnValue(true);
-			vi.spyOn((messageMock.member as GuildMember).permissions, 'has').mockReturnValue(true);
+
+			vi.spyOn(
+				(messageMock.member as GuildMember).permissions,
+				'has',
+			).mockReturnValue(true);
 
 			vi.spyOn(oauthClientMock, 'Introspect').mockResolvedValue([
 				{
@@ -1388,7 +1486,8 @@ Credits:
 
 			await bot.HandleMessage(messageMock);
 
-			expect(messageMock.reply).toHaveBeenCalledWith(`<@123>, there was an error processing your request for \`test test\`
+			expect(messageMock.reply)
+				.toHaveBeenCalledWith(`<@123>, there was an error processing your request for \`test test\`
 \`\`\`
 Invalid argument "test" for "command"!
 Expected "ping, traceroute, dns, mtr, http, auth, limits".

--- a/packages/github/tests/bot.test.ts
+++ b/packages/github/tests/bot.test.ts
@@ -123,6 +123,74 @@ ${expectedResponse.results[0].result.rawOutput}
 			});
 		});
 
+		it('should succesfully handle the command - ping with protocol', async () => {
+			const githubRequest: GithubNotificationRequest = {
+				subject: '',
+				bodyPlain: `@globalping ping google.com --protocol tcp --port 81
+
+--
+Reply to this email directly or view it on GitHub:
+https://github.com/myuser/myrepo/issues/1
+You are receiving this because you were mentioned.
+
+Message ID: <myuser/myrepo/issues/1@github.com>`,
+			};
+
+			postMeasurementMock.mockResolvedValue({
+				id: 'm345ur3m3nt',
+				probesCount: 1,
+			});
+
+			const expectedResponse = getDefaultPingResponse();
+			getMeasurementMock.mockResolvedValue(expectedResponse);
+
+			const req = mockIncomingMessage(
+				{
+					headers: {
+						'api-key': configMock.githubBotApiKey,
+					},
+				},
+				Buffer.from(JSON.stringify(githubRequest)),
+			);
+
+			const res = {
+				writeHead: vi.fn(),
+				write: vi.fn(),
+				end: vi.fn(),
+			} as any;
+
+			await bot.HandleRequest(req, res);
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'ping',
+					target: 'google.com',
+					inProgressUpdates: false,
+					limit: 1,
+					locations: [{ magic: 'world' }],
+					measurementOptions: {
+						protocol: 'TCP',
+						port: 81,
+					},
+				},
+				'globalping_token',
+			);
+
+			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
+
+			expect(githubClientMock.rest.issues.createComment).toHaveBeenCalledWith({
+				owner: 'myuser',
+				repo: 'myrepo',
+				issue_number: 1,
+				body: `Here are the results for \`ping google.com --protocol tcp --port 81\`
+> **Amsterdam, NL, EU, Gigahost AS (AS56655)**
+\`\`\`
+${expectedResponse.results[0].result.rawOutput}
+\`\`\`
+`,
+			});
+		});
+
 		it('should succesfully handle the command - dns', async () => {
 			const githubRequest: GithubNotificationRequest = {
 				subject: '',

--- a/packages/slack/tests/bot.test.ts
+++ b/packages/slack/tests/bot.test.ts
@@ -523,6 +523,100 @@ ${expectedResponse.results[0].result.rawOutput}
 			});
 		});
 
+		it('should handle the command - /ping with protocol', async () => {
+			const payload = {
+				channel_id: 'C07QAK46BGU',
+				user_id: 'U07QAK46BGU',
+				command: '/ping',
+				text: 'google.com from New York --limit 2 --protocol tcp --port 81',
+			} as SlashCommand;
+			const context = {
+				teamId: 'T07QAK46BGU',
+			} as Context & StringIndexed;
+
+			vi.spyOn(slackClientMock.conversations, 'info').mockResolvedValue({} as any);
+
+			vi.spyOn(oauthClientMock, 'GetToken').mockResolvedValue({
+				access_token: 'tok3n',
+			} as AuthToken);
+
+			postMeasurementMock.mockResolvedValue({
+				id: 'm345ur3m3nt',
+				probesCount: 1,
+			});
+
+			const expectedResponse = getDefaultPingResponse();
+			getMeasurementMock.mockResolvedValue(expectedResponse);
+
+			await bot.HandleCommand({
+				ack: ackMock,
+				respond: respondMock,
+				client: slackClientMock,
+				payload,
+				context,
+			} as any);
+
+			expect(ackMock).toHaveBeenCalledTimes(1);
+
+			expect(slackClientMock.conversations.info).toHaveBeenCalledWith({
+				channel: payload.channel_id,
+			});
+
+			expect(oauthClientMock.GetToken).toHaveBeenCalledWith(context.teamId);
+
+			expect(postMeasurementMock).toHaveBeenCalledWith(
+				{
+					type: 'ping',
+					target: 'google.com',
+					inProgressUpdates: false,
+					limit: 2,
+					locations: [{ magic: 'New York' }],
+					measurementOptions: {
+						protocol: 'TCP',
+						port: 81,
+					},
+				},
+				'tok3n',
+			);
+
+			expect(slackClientMock.chat.postEphemeral).toHaveBeenCalledWith({
+				text: '```Processing the request...```',
+				user: payload.user_id,
+				channel: payload.channel_id,
+				thread_ts: undefined,
+			});
+
+			expect(getMeasurementMock).toHaveBeenCalledWith('m345ur3m3nt');
+
+			const expectedBlocks = [
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `<@${payload.user_id}>, here are the results for \`ping ${payload.text}\``,
+						verbatim: true,
+					},
+				},
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `> *Amsterdam, NL, EU, Gigahost AS (AS56655)*
+\`\`\`
+${expectedResponse.results[0].result.rawOutput}
+\`\`\``,
+						verbatim: true,
+					},
+				},
+			];
+			expect(slackClientMock.chat.postMessage).toHaveBeenCalledWith({
+				unfurl_links: false,
+				blocks: expectedBlocks,
+				channel: payload.channel_id,
+				thread_ts: undefined,
+			});
+		});
+
 		it('should handle the command - /traceroute', async () => {
 			const payload = {
 				channel_id: 'C07QAK46BGU',
@@ -1838,7 +1932,7 @@ Documentation and Support: <https://github.com/jsdelivr/globalping>`,
 				text: `Failed to process command \`ping google.com --xyz\`.
 \`\`\`
 Invalid option "xyz" for "ping"!
-Expected "packets, latency, target, from, limit, share".
+Expected "packets, latency, protocol, port, target, from, limit, share".
 \`\`\`
 Documentation and Support: <https://github.com/jsdelivr/globalping>`,
 			});


### PR DESCRIPTION
Note: 
`pnpm discord:deploy-commands` must be run to deploy the commands.

Closes #128 